### PR TITLE
Adding test_env script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Ignore py.test generated dirs
+.cache/
+__pycache__

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 
 python:
     - 2.7
+    - 3.5
 
 sudo: false
 
@@ -15,19 +16,15 @@ addons:
 env:
     global:
         - SETUP_CMD='test'
-        - MAIN_CMD='python setup.py'
+        - TEST_CMD='py.test test_env.py'
+    matrix:
+        - SETUP_CMD='egg_info'
+          env: TEST_CMD='python --version'
+
+        - SETUP_CMD='test'
 
 matrix:
     include:
-        - python: 2.7
-          env: SETUP_CMD='test'
-               TEST_CMD='python --version'
-        - python: 3.5
-          env: SETUP_CMD='test'
-               TEST_CMD='python --version'
-        - python: 3.5
-          env: SETUP_CMD='egg_info'
-               TEST_CMD='python --version'
         - python: 3.5
           env: SETUP_CMD='build_sphinx'
                TEST_CMD='python -c "import sphinx"'
@@ -35,27 +32,25 @@ matrix:
           env: MAIN_CMD='pep8'
                TEST_CMD='pep8 --version'
         - python: 3.5
-          env: SETUP_CMD='test' NUMPY_VERSION=1.10 
-               TEST_CMD='python -c "import numpy; assert numpy.__version__.startswith(\"1.10\")"'
+          env: SETUP_CMD='test' NUMPY_VERSION=1.10
+
         - python: 3.5
           env: SETUP_CMD='test' ASTROPY_VERSION=1.0
-               TEST_CMD='python -c "import astropy; assert astropy.__version__.startswith(\"1.0\")"'
+
         - python: 3.5
           env: SETUP_CMD='test' NUMPY_VERSION=1.9 CONDA_DEPENDENCIES='requests'
-               TEST_CMD='python -c "import numpy; import requests; assert numpy.__version__.startswith(\"1.9\")"'
+
         - python: 3.5
           env: SETUP_CMD='test' NUMPY_VERSION=1.9 ASTROPY_VERSION=1.0
                CONDA_DEPENDENCIES='matplotlib h5py' PIP_DEPENDENCIES='astrodendro'
-               TEST_CMD='python -c "import astrodendro"'
         - python: 3.5
           env: SETUP_CMD='test' NUMPY_VERSION=dev
-               TEST_CMD='python -c "import numpy"'
+
         - python: 3.5
           env: SETUP_CMD='test' NUMPY_VERSION=1.10 ASTROPY_VERSION=dev
-               TEST_CMD='python -c "import astropy"'
+
         - python: 2.7
           env: SETUP_CMD='test'
-               TEST_CMD='python -c "import PyQt5"'
                CONDA_CHANNELS='astropy-ci-extras astrofrog'
                CONDA_DEPENDENCIES='pyqt5'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ matrix:
         - python: 2.7
           env: SETUP_CMD='test'
                CONDA_CHANNELS='astropy-ci-extras astrofrog'
-               CONDA_DEPENDENCIES='pyqt5'
+               CONDA_DEPENDENCIES='PyQt5'
 
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ matrix:
     include:
         - python: 3.5
           env: SETUP_CMD='build_sphinx'
-               TEST_CMD='python -c "import sphinx"'
+
         - python: 3.5
           env: MAIN_CMD='pep8'
                TEST_CMD='pep8 --version'

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ env:
         - TEST_CMD='py.test test_env.py'
     matrix:
         - SETUP_CMD='egg_info'
-          env: TEST_CMD='python --version'
+          TEST_CMD='python --version'
 
         - SETUP_CMD='test'
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,6 +20,18 @@ environment:
       - PYTHON_VERSION: "3.5"
         NUMPY_VERSION: "1.10"
 
+      - PYTHON_VERSION: "3.4"
+        NUMPY_VERSION: "1.9"
+        ASTROPY_VERSION: "development"
+
+      - PYTHON_VERSION: "3.4"
+        NUMPY_VERSION: "1.9"
+        ASTROPY_VERSION: "stable"
+
+      - PYTHON_VERSION: "3.4"
+        NUMPY_VERSION: "1.9"
+        ASTROPY_VERSION: "1.0"
+
 
 platform:
     -x64

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,23 +15,30 @@ environment:
 
       - PYTHON_VERSION: "2.6"
         NUMPY_VERSION: "1.9"
+        TEST_CMD: "import numpy; assert numpy.__version__.startswith(\"1.9\")"
+
       - PYTHON_VERSION: "3.4"
         NUMPY_VERSION: "1.9"
+        TEST_CMD: "import numpy; assert numpy.__version__.startswith(\"1.9\")"
+
       - PYTHON_VERSION: "3.5"
         NUMPY_VERSION: "1.10"
+        TEST_CMD: "import numpy; assert numpy.__version__.startswith(\"1.10\")"
 
-      - PYTHON_VERSION: "3.4"
-        NUMPY_VERSION: "1.9"
+      - PYTHON_VERSION: "3.5"
+        NUMPY_VERSION: "1.10"
         ASTROPY_VERSION: "development"
+        TEST_CMD: "import numpy; assert numpy.__version__.startswith(\"1.10\"); import astropy; assert astropy.__version__.startswith(\"1.1\")"
 
-      - PYTHON_VERSION: "3.4"
-        NUMPY_VERSION: "1.9"
+      - PYTHON_VERSION: "3.5"
+        NUMPY_VERSION: "1.10"
         ASTROPY_VERSION: "stable"
+        TEST_CMD: "import numpy; assert numpy.__version__.startswith(\"1.10\"); import astropy; assert astropy.__version__.startswith(\"1.0\")"
 
-      - PYTHON_VERSION: "3.4"
-        NUMPY_VERSION: "1.9"
+      - PYTHON_VERSION: "3.5"
+        NUMPY_VERSION: "1.10"
         ASTROPY_VERSION: "1.0"
-
+        TEST_CMD: "import numpy; assert numpy.__version__.startswith(\"1.10\"); import astropy; assert astropy.__version__.startswith(\"1.0\")"
 
 platform:
     -x64
@@ -54,5 +61,5 @@ install:
 build: false
 
 test_script:
-  - "%CMD_IN_ENV% python --version"
+  - "%CMD_IN_ENV% python -c %TEST_CMD%"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,14 +13,13 @@ environment:
 
   matrix:
 
-      # We test Python 2.6 and 3.4 because 2.6 is most likely to have issues in
-      # Python 2 (if 2.6 passes, 2.7 virtually always passes) and Python 3.4 is
-      # the latest Python 3 release.
-
       - PYTHON_VERSION: "2.6"
-        NUMPY_VERSION: "1.9.1"
+        NUMPY_VERSION: "1.9"
       - PYTHON_VERSION: "3.4"
-        NUMPY_VERSION: "1.9.1"
+        NUMPY_VERSION: "1.9"
+      - PYTHON_VERSION: "3.5"
+        NUMPY_VERSION: "1.10"
+
 
 platform:
     -x64
@@ -39,7 +38,7 @@ install:
     - "conda --version"
     - "python --version"
 
-# Not a .NET project, we build SunPy in the install step instead
+# Not a .NET project, we build ci-helpers in the install step instead
 build: false
 
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -46,7 +46,7 @@ platform:
 install:
 
     # Install Miniconda
-    - "git clone git://github.com/astropy/ci-helpers.git"
+    - "git clone . ci-helpers"
     - "powershell ci-helpers/appveyor/install-miniconda.ps1"
 
     # Set path again, need to find a way to avoid doing this again

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,35 +10,30 @@ environment:
       PYTHON_ARCH: "64" # needs to be set for CMD_IN_ENV to succeed. If a mix
                         # of 32 bit and 64 bit builds are needed, move this
                         # to the matrix section.
+      TEST_CMD: "py.test test_env.py"
 
   matrix:
 
       - PYTHON_VERSION: "2.6"
         NUMPY_VERSION: "1.9"
-        TEST_CMD: "import numpy; assert numpy.__version__.startswith(\"1.9\")"
 
       - PYTHON_VERSION: "3.4"
         NUMPY_VERSION: "1.9"
-        TEST_CMD: "import numpy; assert numpy.__version__.startswith(\"1.9\")"
 
       - PYTHON_VERSION: "3.5"
         NUMPY_VERSION: "1.10"
-        TEST_CMD: "import numpy; assert numpy.__version__.startswith(\"1.10\")"
 
       - PYTHON_VERSION: "3.5"
         NUMPY_VERSION: "1.10"
         ASTROPY_VERSION: "development"
-        TEST_CMD: "import numpy; assert numpy.__version__.startswith(\"1.10\"); import astropy; assert astropy.__version__.startswith(\"1.1\")"
 
       - PYTHON_VERSION: "3.5"
         NUMPY_VERSION: "1.10"
         ASTROPY_VERSION: "stable"
-        TEST_CMD: "import numpy; assert numpy.__version__.startswith(\"1.10\"); import astropy; assert astropy.__version__.startswith(\"1.0\")"
 
       - PYTHON_VERSION: "3.5"
         NUMPY_VERSION: "1.10"
         ASTROPY_VERSION: "1.0"
-        TEST_CMD: "import numpy; assert numpy.__version__.startswith(\"1.10\"); import astropy; assert astropy.__version__.startswith(\"1.0\")"
 
 platform:
     -x64
@@ -61,5 +56,5 @@ install:
 build: false
 
 test_script:
-  - "%CMD_IN_ENV% python -c %TEST_CMD%"
+  - "%CMD_IN_ENV% %TEST_CMD%"
 

--- a/appveyor/install-miniconda.ps1
+++ b/appveyor/install-miniconda.ps1
@@ -88,10 +88,10 @@ $env:PATH = "C:\conda\envs\test;C:\conda\envs\test\Scripts;C:\conda\envs\test\Li
 python --version
 
 # Install the specified versions of numpy and other dependencies
-if ($env:CONDA_DEPENDENCIES -eq "") {
-   conda install -n test -q pytest numpy=$env:NUMPY_VERSION
-} else {
+if ($env:CONDA_DEPENDENCIES) {
    conda install -n test -q pytest numpy=$env:NUMPY_VERSION $env:CONDA_DEPENDENCIES.Split(" ")
+} else {
+   conda install -n test -q pytest numpy=$env:NUMPY_VERSION
 }
 
 # Check whether astropy is required and if yes install it

--- a/appveyor/install-miniconda.ps1
+++ b/appveyor/install-miniconda.ps1
@@ -95,6 +95,12 @@ if ($env:CONDA_DEPENDENCIES -eq "") {
 }
 
 # Check whether astropy is required and if yes install it
-if ($env:ASTROPY_VERSION) {
+if ($env:ASTROPY_VERSION -match "dev") {
+   # Install pip and Astropy core build dependencies first
+   conda install -n test -q numpy=$env:NUMPY_VERSION Cython jinja2 pip
+   pip install git+http://github.com/astropy/astropy.git#egg=astropy
+} elseif ($env:ASTROPY_VERSION -match "stable") {
+   conda install -n test -q numpy=$env:NUMPY_VERSION astropy
+} elseif ($env:ASTROPY_VERSION) {
    conda install -n test -q numpy=$env:NUMPY_VERSION astropy=$env:ASTROPY_VERSION
 }

--- a/test_env.py
+++ b/test_env.py
@@ -43,3 +43,9 @@ def test_astropy():
 def test_dependency_imports():
     for package in dependency_list:
         __import__(package)
+
+
+def test_sphinx():
+    if 'SETUP_CMD' in os.environ:
+        if 'build_sphinx' in os.environ['SETUP_CMD']:
+            import sphinx

--- a/test_env.py
+++ b/test_env.py
@@ -19,7 +19,7 @@ dependency_list = PIP_DEPENDENCIES + CONDA_DEPENDENCIES
 
 
 def test_numpy():
-    if os.environ.get('NUMPY_VERSION', None) is not None:
+    if 'NUMPY_VERSION' in os.environ:
         import numpy
         try:
             assert numpy.__version__.startswith(os.environ['NUMPY_VERSION'])
@@ -28,7 +28,7 @@ def test_numpy():
 
 
 def test_astropy():
-    if os.environ.get('ASTROPY_VERSION', None) is not None:
+    if 'ASTROPY_VERSION' in os.environ:
         import astropy
         try:
             assert astropy.__version__.startswith(os.environ['ASTROPY_VERSION'])

--- a/test_env.py
+++ b/test_env.py
@@ -1,0 +1,45 @@
+import os
+
+# The test scripts accept 'stable' for ASTROPY_VERSION to test that it's
+# properly parsed hard-wire the latest stable branch version here
+
+LATEST_ASTROPY_STABLE = '1.0'
+
+if os.environ.get('PIP_DEPENDENCIES', None) is not None:
+    PIP_DEPENDENCIES = os.environ['PIP_DEPENDENCIES'].split(' ')
+else:
+    PIP_DEPENDENCIES = []
+
+if os.environ.get('CONDA_DEPENDENCIES', None) is not None:
+    CONDA_DEPENDENCIES = os.environ['CONDA_DEPENDENCIES'].split(' ')
+else:
+    CONDA_DEPENDENCIES = []
+
+dependency_list = PIP_DEPENDENCIES + CONDA_DEPENDENCIES
+
+
+def test_numpy():
+    if os.environ.get('NUMPY_VERSION', None) is not None:
+        import numpy
+        try:
+            assert numpy.__version__.startswith(os.environ['NUMPY_VERSION'])
+        except AssertionError:
+            assert 'dev' in numpy.__version__
+
+
+def test_astropy():
+    if os.environ.get('ASTROPY_VERSION', None) is not None:
+        import astropy
+        try:
+            assert astropy.__version__.startswith(os.environ['ASTROPY_VERSION'])
+        except AssertionError:
+            if os.environ['ASTROPY_VERSION'] == 'stable':
+                assert astropy.__version__.startswith(LATEST_ASTROPY_STABLE)
+            else:
+                assert 'dev' in astropy.__version__
+
+
+# Check whether everything is installed and importable
+def test_dependency_imports():
+    for package in dependency_list:
+        __import__(package)


### PR DESCRIPTION
As discussed on gitter, adding a python script to run in the appveyor and travis tests has several benefits. 

The most obvious that it circumvent the parsing issues of the ``appveyor.yml`` file, so not only one liners can be run.

It also enables us to to a more thorough testing, and easy extension in the future.

Fixes #10