### PR TITLE
Make pip output quiet

### DIFF
--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -36,7 +36,7 @@ fi
 # CORE DEPENDENCIES
 conda install -q pytest pip
 
-export PIP_INSTALL='pip install'
+export PIP_INSTALL='pip install -q'
 
 # PEP8
 if [[ $MAIN_CMD == pep8* ]]; then


### PR DESCRIPTION
This should get rid of progress bars (which clutter CI logs otherwise). Need to check before merging.