### PR TITLE
Update install-miniconda.ps1

### DIFF
--- a/appveyor/install-miniconda.ps1
+++ b/appveyor/install-miniconda.ps1
@@ -43,8 +43,8 @@ function DownloadMiniconda ($version, $platform_suffix) {
    return $filepath
 }
 
-function InstallMiniconda ($python_version, $architecture, $python_home) {
-    Write-Host "Installing miniconda" $python_version "for" $architecture "bit architecture to" $python_home
+function InstallMiniconda ($miniconda_version, $architecture, $python_home) {
+    Write-Host "Installing miniconda" $miniconda_version "for" $architecture "bit architecture to" $python_home
     if (Test-Path $python_home) {
         Write-Host $python_home "already exists, skipping."
         return $false
@@ -54,14 +54,14 @@ function InstallMiniconda ($python_version, $architecture, $python_home) {
     } else {
         $platform_suffix = "x86_64"
     }
-    $filepath = DownloadMiniconda $python_version $platform_suffix
+    $filepath = DownloadMiniconda $miniconda_version $platform_suffix
     Write-Host "Installing" $filepath "to" $python_home
     $args = "/InstallationType=AllUsers /S /AddToPath=1 /RegisterPython=1 /D=" + $python_home
     Write-Host $filepath $args
     Start-Process -FilePath $filepath -ArgumentList $args -Wait -Passthru
     #Start-Sleep -s 15
     if (Test-Path $python_home) {
-        Write-Host "Miniconda $python_version ($architecture) installation complete"
+        Write-Host "Miniconda $miniconda_version ($architecture) installation complete"
     } else {
         Write-Host "Failed to install Python in $python_home"
         Exit 1


### PR DESCRIPTION
Change confusing variable name--I expected `python_version` to be something like "2.7" or "3.4", whereas this is the version of the miniconda distributable.  I'm tempted also to change `python_home` to `miniconda_home`, but that is filled below from an environment variable called just "PYTHON" which I'm tempted to also rename to "CONDA" or something.