### PR TITLE
Set up Windows SDK when calling pip install

### DIFF
--- a/appveyor/install-miniconda.ps1
+++ b/appveyor/install-miniconda.ps1
@@ -130,9 +130,9 @@ conda install -n test -q pytest $NUMPY_OPTION $ASTROPY_OPTION $CONDA_DEPENDENCIE
 
 # Check whether the developer version of Numpy is required and if yes install it
 if ($env:NUMPY_VERSION -match "dev") {
-   pip install git+http://github.com/numpy/numpy.git#egg=numpy
+   Invoke-Expression "${env:CMD_IN_ENV} pip install git+http://github.com/numpy/numpy.git#egg=numpy"
 }
 # Check whether the developer version of Astropy is required and if yes install it
 if ($env:ASTROPY_VERSION -match "dev") {
-   pip install git+http://github.com/astropy/astropy.git#egg=astropy
+   Invoke-Expression "${env:CMD_IN_ENV} pip install git+http://github.com/astropy/astropy.git#egg=astropy"
 }


### PR DESCRIPTION
pip installs should be preceded by the `%CMD_IN_ENV%` invokation to set up the Windows SDK environment when appropriate, since pip install will often (not always, depending on wheel availability) result in a build from source, in which case we presumably want to build for the same platform as the package that we're testing.