### PR TITLE
Adding 'set -e' to the install script

### DIFF
--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -2,6 +2,8 @@
 
 hash -r
 
+set -e
+
 conda config --set always_yes yes --set changeps1 no
 
 if [[ -z $ASTROPY_LTS_VERSION ]]; then


### PR DESCRIPTION
As discussed in #27 it has advantages to fail the build when something goes wrong with the installs (rather than let the test run and produce random failures that are mostly unrelated to the given package).