### PR TITLE
NUMPY_VERSION=dev not working if installing other conda packages that depend on Numpy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,8 +47,13 @@ matrix:
         - python: 3.5
           env: SETUP_CMD='test' NUMPY_VERSION=1.9 ASTROPY_VERSION=1.0
                CONDA_DEPENDENCIES='matplotlib h5py' PIP_DEPENDENCIES='astrodendro'
+
+        # For the Numpy dev build, we also specify a conda package that depends
+        # on Numpy to make sure that Numpy dev is used (because conda will also
+        # install Numpy stable)
         - python: 3.5
           env: SETUP_CMD='test' NUMPY_VERSION=dev
+               CONDA_DEPENDENCIES='scipy'
 
         - python: 3.5
           env: SETUP_CMD='test' NUMPY_VERSION=stable

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,8 +19,12 @@ environment:
       - PYTHON_VERSION: "2.7"
         NUMPY_VERSION: "stable"
 
+        # For the Numpy dev build, we also specify a conda package that depends
+        # on Numpy to make sure that Numpy dev is used (because conda will also
+        # install Numpy stable)
       - PYTHON_VERSION: "2.7"
         NUMPY_VERSION: "development"
+        CONDA_DEPENDENCIES: "scipy"
 
       - PYTHON_VERSION: "2.6"
         NUMPY_VERSION: "1.9"

--- a/appveyor/install-miniconda.ps1
+++ b/appveyor/install-miniconda.ps1
@@ -130,9 +130,9 @@ conda install -n test -q pytest $NUMPY_OPTION $ASTROPY_OPTION $CONDA_DEPENDENCIE
 
 # Check whether the developer version of Numpy is required and if yes install it
 if ($env:NUMPY_VERSION -match "dev") {
-   Invoke-Expression "${env:CMD_IN_ENV} pip install git+http://github.com/numpy/numpy.git#egg=numpy"
+   Invoke-Expression "${env:CMD_IN_ENV} pip install git+http://github.com/numpy/numpy.git#egg=numpy --upgrade"
 }
 # Check whether the developer version of Astropy is required and if yes install it
 if ($env:ASTROPY_VERSION -match "dev") {
-   Invoke-Expression "${env:CMD_IN_ENV} pip install git+http://github.com/astropy/astropy.git#egg=astropy"
+   Invoke-Expression "${env:CMD_IN_ENV} pip install git+http://github.com/astropy/astropy.git#egg=astropy --upgrade"
 }

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -50,8 +50,10 @@ if [[ $MAIN_CMD == pep8* ]]; then
     return  # no more dependencies needed
 fi
 
-# NUMPY (for Numpy dev see lower down)
-if [[ $NUMPY_VERSION == stable ]]; then
+# NUMPY
+if [[ $NUMPY_VERSION == dev* ]]; then
+    : # Install at the bottom of this script
+elif [[ $NUMPY_VERSION == stable ]]; then
     conda install -q numpy
     export CONDA_INSTALL="conda install -q python=$PYTHON_VERSION"
 elif [[ ! -z $NUMPY_VERSION ]]; then
@@ -64,7 +66,7 @@ fi
 # ASTROPY
 if [[ ! -z $ASTROPY_VERSION ]]; then
     if [[ $ASTROPY_VERSION == dev* ]]; then
-        # Install at the bottom of this script
+        : # Install at the bottom of this script
     elif [[ $ASTROPY_VERSION == stable ]]; then
         $CONDA_INSTALL astropy
     elif [[ $ASTROPY_VERSION == lts ]]; then

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -104,10 +104,10 @@ fi
 
 # COVERAGE DEPENDENCIES
 if [[ $SETUP_CMD == *coverage* ]]; then
-  # TODO can use latest version of coverage (4.0) once astropy 1.1 is out
-  # with the fix of https://github.com/astropy/astropy/issues/4175.
-  $CONDA_INSTALL coverage==3.7.1
-  $PIP_INSTALL coveralls
+    # TODO can use latest version of coverage (4.0) once astropy 1.1 is out
+    # with the fix of https://github.com/astropy/astropy/issues/4175.
+    $CONDA_INSTALL coverage==3.7.1
+    $PIP_INSTALL coveralls
 fi
 
 # NUMPY DEV

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -50,12 +50,8 @@ if [[ $MAIN_CMD == pep8* ]]; then
     return  # no more dependencies needed
 fi
 
-# NUMPY
-if [[ $NUMPY_VERSION == dev ]] || [[ $NUMPY_VERSION == development ]]; then
-    conda install -q Cython
-    $PIP_INSTALL git+http://github.com/numpy/numpy.git
-    export CONDA_INSTALL="conda install -q python=$PYTHON_VERSION"
-elif [[ $NUMPY_VERSION == stable ]]; then
+# NUMPY (for Numpy dev see lower down)
+if [[ $NUMPY_VERSION == stable ]]; then
     conda install -q numpy
     export CONDA_INSTALL="conda install -q python=$PYTHON_VERSION"
 elif [[ ! -z $NUMPY_VERSION ]]; then
@@ -67,10 +63,8 @@ fi
 
 # ASTROPY
 if [[ ! -z $ASTROPY_VERSION ]]; then
-    if [[ $ASTROPY_VERSION == development ]] || [[ $ASTROPY_VERSION == dev ]]; then
-        # Install Astropy core dependencies first
-        $CONDA_INSTALL Cython jinja2
-        $PIP_INSTALL git+http://github.com/astropy/astropy.git#egg=astropy
+    if [[ $ASTROPY_VERSION == dev* ]]; then
+        # Install at the bottom of this script
     elif [[ $ASTROPY_VERSION == stable ]]; then
         $CONDA_INSTALL astropy
     elif [[ $ASTROPY_VERSION == lts ]]; then
@@ -114,4 +108,27 @@ if [[ $SETUP_CMD == *coverage* ]]; then
   # with the fix of https://github.com/astropy/astropy/issues/4175.
   $CONDA_INSTALL coverage==3.7.1
   $PIP_INSTALL coveralls
+fi
+
+# NUMPY DEV
+
+# We now install Numpy dev - this has to be done last, otherwise conda might 
+# install a stable version of Numpy as a dependency to another package, which 
+# would override Numpy dev.
+
+if [[ $NUMPY_VERSION == dev* ]]; then
+    conda install -q Cython
+    $PIP_INSTALL git+http://github.com/numpy/numpy.git
+fi
+
+# ASTROPY DEV
+
+# We now install Astropy dev - this has to be done last, otherwise conda might 
+# install a stable version of Astropy as a dependency to another package, which 
+# would override Astropy dev. Also, if we are installing Numpy dev, we need to 
+# compile Astropy dev against Numpy dev.
+
+if [[ $ASTROPY_VERSION == dev* ]]; then
+    $CONDA_INSTALL Cython jinja2
+    $PIP_INSTALL git+http://github.com/astropy/astropy.git#egg=astropy
 fi

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -53,6 +53,7 @@ fi
 # NUMPY
 if [[ $NUMPY_VERSION == dev* ]]; then
     : # Install at the bottom of this script
+    export CONDA_INSTALL="conda install -q python=$PYTHON_VERSION"
 elif [[ $NUMPY_VERSION == stable ]]; then
     conda install -q numpy
     export CONDA_INSTALL="conda install -q python=$PYTHON_VERSION"

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -121,7 +121,7 @@ fi
 
 if [[ $NUMPY_VERSION == dev* ]]; then
     conda install -q Cython
-    $PIP_INSTALL git+http://github.com/numpy/numpy.git
+    $PIP_INSTALL git+http://github.com/numpy/numpy.git#egg=numpy --upgrade
 fi
 
 # ASTROPY DEV
@@ -133,5 +133,5 @@ fi
 
 if [[ $ASTROPY_VERSION == dev* ]]; then
     $CONDA_INSTALL Cython jinja2
-    $PIP_INSTALL git+http://github.com/astropy/astropy.git#egg=astropy
+    $PIP_INSTALL git+http://github.com/astropy/astropy.git#egg=astropy --upgrade
 fi


### PR DESCRIPTION
In the following build:

https://travis-ci.org/glue-viz/glue/jobs/100871829

Numpy dev is installed, followed by conda packages, which includes Numpy, which takes precedence, so Numpy dev is ignored.