### PR TITLE
Removing conda info command from the build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Following this, various dependencies are installed depending on the following en
   channel names, and defaults to ``astropy-ci-extras``.
 
 * ``$DEBUG``: if `True` this turns on the shell debug mode in the install
-  scripts
+  scripts, and provides information on the current conda install.
 
 The idea behind the ``MAIN_CMD`` and ``SETUP_CMD`` environment variables is
 that the ``script`` section of the ``.travis.yml`` file can be set to:

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -139,7 +139,7 @@ fi
 
 if [[ $DEBUG == True ]]; then
     # include debug information about the current conda install
-    $CONDA_INSTALL _license
+    conda install -n root _license
     conda info -a
 fi
 

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -22,7 +22,6 @@ do
 done
 
 conda update -q conda
-conda info -a
 
 # Use utf8 encoding. Should be default, but this is insurance against
 # future changes

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -137,4 +137,10 @@ if [[ $ASTROPY_VERSION == dev* ]]; then
     $PIP_INSTALL git+http://github.com/astropy/astropy.git#egg=astropy --upgrade
 fi
 
+if [[ $DEBUG == True ]]; then
+    # include debug information about the current conda install
+    $CONDA_INSTALL _license
+    conda info -a
+fi
+
 set +x


### PR DESCRIPTION
as it's really only for debugging, and the warnings it generates messes up the sphinx builds warning catching system.