### PR TITLE
Fix matplotlib version to 1.5.0 for travis-ci sphinx builds

### DIFF
--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -103,7 +103,9 @@ fi
 # DOCUMENTATION DEPENDENCIES
 # build_sphinx needs sphinx and matplotlib (for plot_directive).
 if [[ $SETUP_CMD == build_sphinx* ]] || [[ $SETUP_CMD == build_docs* ]]; then
-    $CONDA_INSTALL Sphinx matplotlib
+    # TODO: remove pinned matplotlib version once
+    # https://github.com/matplotlib/matplotlib/issues/5836 is fixed
+    $CONDA_INSTALL Sphinx matplotlib=1.5.0
 fi
 
 # COVERAGE DEPENDENCIES


### PR DESCRIPTION
`travis-ci` sphinx builds will fail with `matplotlib 1.5.1` because of a warning about `fc-list`.  This PR can be reverted once https://github.com/matplotlib/matplotlib/issues/5836 is fixed.