### PR TITLE
Have a way to provide options to conda

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -99,6 +99,12 @@ matrix:
                CONDA_DEPENDENCIES='pyqt5' DEBUG=True
                NUMPY_VERSION=1.10 ASTROPY_VERSION=lts
 
+        - os: linux
+          env: SETUP_CMD='test' CONDA_DEPENDENCIES='matplotlib' CONDA_DEPENDENCIES_FLAGS='--no-deps'
+
+        - os: linux
+          env: SETUP_CMD='test' PIP_DEPENDENCIES='pyparsing' PIP_DEPENDENCIES='--log pip_install.log'
+
 before_install:
     - ln -s . ci-helpers
     - source ci-helpers/travis/setup_conda_$TRAVIS_OS_NAME.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -103,7 +103,7 @@ matrix:
           env: SETUP_CMD='test' CONDA_DEPENDENCIES='matplotlib' CONDA_DEPENDENCIES_FLAGS='--no-deps'
 
         - os: linux
-          env: SETUP_CMD='test' PIP_DEPENDENCIES='pyparsing' PIP_DEPENDENCIES='--log pip_install.log'
+          env: SETUP_CMD='test' PIP_DEPENDENCIES='pyparsing' PIP_DEPENDENCIES_FLAGS='--log pip_install.log'
 
 before_install:
     - ln -s . ci-helpers

--- a/README.md
+++ b/README.md
@@ -81,10 +81,10 @@ Following this, various dependencies are installed depending on the following en
   names that will be installed with pip.
 
 * ``CONDA_DEPENDENCIES_FLAGS``: additional flags to pass to conda when
-  instlaling ``CONDA_DEPENDENCIES``
+  installing ``CONDA_DEPENDENCIES``
 
 * ``PIP_DEPENDENCIES_FLAGS``: additional flags to pass to pip when
-  instlaling ``PIP_DEPENDENCIES``
+  installing ``PIP_DEPENDENCIES``
 
 * ``$CONDA_CHANNELS``: this should be a space-separated string of conda
   channel names, and defaults to ``astropy-ci-extras``.

--- a/README.md
+++ b/README.md
@@ -80,6 +80,12 @@ Following this, various dependencies are installed depending on the following en
 * ``$PIP_DEPENDENCIES``: this should be a space-separated string of package
   names that will be installed with pip.
 
+* ``CONDA_DEPENDENCIES_FLAGS``: additional flags to pass to conda when
+  instlaling ``CONDA_DEPENDENCIES``
+
+* ``PIP_DEPENDENCIES_FLAGS``: additional flags to pass to pip when
+  instlaling ``PIP_DEPENDENCIES``
+
 * ``$CONDA_CHANNELS``: this should be a space-separated string of conda
   channel names, and defaults to ``astropy-ci-extras``.
 

--- a/test_env.py
+++ b/test_env.py
@@ -87,6 +87,28 @@ def test_open_files():
     if 'open-files' in os.environ.get('SETUP_CMD', ''):
         import psutil
 
+
+def test_conda_flags():
+    if (os.environ.get('CONDA_DEPENDENCIES_FLAGS', None) == '--no-deps'
+        and os.environ.get('CONDA_DEPENDENCIES', None) == 'matplotlib'):
+        try:
+            import numpy
+        except:
+            pass
+        else:
+            raise Exception("Numpy should not be installed")
+    else:
+        pytest.skip()
+
+
+def test_pip_flags():
+    pip_flags = os.environ.get('PIP_DEPENDENCIES_FLAGS', None)
+    if pip_flags.startswith('--log'):
+        assert os.path.exists(pip_flags.split()[1])
+    else:
+        pytest.skip()
+
+
 if __name__ == '__main__':
     import pytest
     pytest.main(__file__)

--- a/test_env.py
+++ b/test_env.py
@@ -2,6 +2,8 @@ import os
 import re
 import sys
 
+import pytest
+
 # The test scripts accept 'stable' for ASTROPY_VERSION to test that it's
 # properly parsed hard-wire the latest stable branch version here
 
@@ -67,6 +69,12 @@ def test_astropy():
 
 # Check whether everything is installed and importable
 def test_dependency_imports():
+
+    # We have to ignore the special case where we are running with --no-deps
+    # because we don't expect that import to work.
+    if os.environ.get('CONDA_DEPENDENCIES_FLAGS', '') == '--no-deps':
+        pytest.skip()
+
     for package in dependency_list:
         if package == 'pyqt5':
             __import__('PyQt5')
@@ -89,8 +97,8 @@ def test_open_files():
 
 
 def test_conda_flags():
-    if (os.environ.get('CONDA_DEPENDENCIES_FLAGS', None) == '--no-deps'
-        and os.environ.get('CONDA_DEPENDENCIES', None) == 'matplotlib'):
+    if (os.environ.get('CONDA_DEPENDENCIES_FLAGS', '') == '--no-deps'
+        and os.environ.get('CONDA_DEPENDENCIES', '') == 'matplotlib'):
         try:
             import numpy
         except:
@@ -102,7 +110,7 @@ def test_conda_flags():
 
 
 def test_pip_flags():
-    pip_flags = os.environ.get('PIP_DEPENDENCIES_FLAGS', None)
+    pip_flags = os.environ.get('PIP_DEPENDENCIES_FLAGS', '')
     if pip_flags.startswith('--log'):
         assert os.path.exists(pip_flags.split()[1])
     else:

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -16,6 +16,14 @@ if [[ -z $CONDA_CHANNELS ]]; then
     CONDA_CHANNELS=astropy-ci-extras
 fi
 
+if [[ -z $CONDA_DEPENDENCIES_FLAGS ]]; then
+   CONDA_DEPENDENCIES_FLAGS=''
+fi
+
+if [[ -z $PIP_DEPENDENCIES_FLAGS ]]; then
+   PIP_DEPENDENCIES_FLAGS=''
+fi
+
 for channel in $CONDA_CHANNELS
 do
     conda config --add channels $channel
@@ -116,11 +124,11 @@ fi
 
 # ADDITIONAL DEPENDENCIES (can include optionals, too)
 if [[ ! -z $CONDA_DEPENDENCIES ]]; then
-    $CONDA_INSTALL $CONDA_DEPENDENCIES
+    $CONDA_INSTALL $CONDA_DEPENDENCIES $CONDA_DEPENDENCIES_FLAGS
 fi
 
 if [[ ! -z $PIP_DEPENDENCIES ]]; then
-    $PIP_INSTALL $PIP_DEPENDENCIES
+    $PIP_INSTALL $PIP_DEPENDENCIES $PIP_DEPENDENCIES_FLAGS
 fi
 
 # PARALLEL BUILDS


### PR DESCRIPTION
In Glue, I was passing flags to conda using e.g.

```
CONDA_DEPENDENCIES='numpy scipy --no-deps'
```

this is now broken BUT I think that's fine, since this isn't really a proper way to do it. So I would suggest we add a new variable ``$CONDA_FLAGS`` to deal with passing any flags such as this.