### PR TITLE
Various enhanchements for the travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,7 +72,8 @@ matrix:
           env: SETUP_CMD='test' ASTROPY_VERSION=stable
 
         - os: linux
-          env: SETUP_CMD='test' NUMPY_VERSION=1.9 CONDA_DEPENDENCIES='requests'
+          env: SETUP_CMD='test' NUMPY_VERSION=1.9
+               CONDA_DEPENDENCIES='jinja2=2.8' DEBUG=True
 
         - os: linux
           env: SETUP_CMD='test' NUMPY_VERSION=1.9 ASTROPY_VERSION=1.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,7 +72,7 @@ matrix:
           env: SETUP_CMD='test' ASTROPY_VERSION=stable
 
         - os: linux
-          env: SETUP_CMD='test' NUMPY_VERSION=1.9
+          env: SETUP_CMD='test' NUMPY_VERSION=stable
                CONDA_DEPENDENCIES='jinja2=2.8' DEBUG=True
 
         - os: linux
@@ -81,7 +81,8 @@ matrix:
                PIP_DEPENDENCIES='astrodendro'
 
         - os: linux
-          env: SETUP_CMD='test' NUMPY_VERSION=stable
+          env: SETUP_CMD='test' CONDA_DEPENDENCIES='matplotlib=1.5'
+               TEST_CMD='python -c "import matplotlib; assert int(matplotlib.__version__[-1])>0"'
 
         - os: linux
           env: SETUP_CMD='test' ASTROPY_VERSION=LTS

--- a/README.md
+++ b/README.md
@@ -90,7 +90,8 @@ Following this, various dependencies are installed depending on the following en
   channel names, and defaults to ``astropy-ci-extras``.
 
 * ``$DEBUG``: if `True` this turns on the shell debug mode in the install
-  scripts, and provides information on the current conda install.
+  scripts, and provides information on the current conda install and
+  switches off the ``-q`` conda flag for verbose output.
 
 * ``$SETUP_XVFB``: if True this makes sure e.g., interactive matplotlib
   backends work by starting up a X virtual framebuffer.

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -83,6 +83,12 @@ if [[ ! -z $CONDA_DEPENDENCIES ]]; then
        fi
     done
 
+    # Do in the pin file what conda silently does on the command line, to
+    # extend the underspecified version numbers with *
+    awk -F == '{if (NF==1) print $0; else print $1, $2"*"}' \
+        $pin_file > /tmp/pin_file_temp
+    mv /tmp/pin_file_temp $pin_file
+
     # We should remove the version numbers from CONDA_DEPENDENCIES to avoid
     # the conflict with the *_VERSION env variables
     CONDA_DEPENDENCIES=$(awk '{printf tolower($1)" "}' $pin_file)

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -8,6 +8,12 @@ conda config --set always_yes yes --set changeps1 no
 
 shopt -s nocasematch
 
+if [[ $DEBUG == True ]]; then
+    QUIET=''
+else
+    QUIET='-q'
+fi
+
 if [[ -z $ASTROPY_LTS_VERSION ]]; then
    ASTROPY_LTS_VERSION=1.0
 fi
@@ -29,7 +35,7 @@ do
     conda config --add channels $channel
 done
 
-conda update -q conda
+conda update $QUIET conda
 
 # Use utf8 encoding. Should be default, but this is insurance against
 # future changes
@@ -40,7 +46,7 @@ if [[ -z $PYTHON_VERSION ]]; then
 fi
 
 # CONDA
-conda create -q -n test python=$PYTHON_VERSION
+conda create $QUIET -n test python=$PYTHON_VERSION
 source activate test
 
 # EGG_INFO
@@ -49,7 +55,7 @@ if [[ $SETUP_CMD == egg_info ]]; then
 fi
 
 # CORE DEPENDENCIES
-conda install -q pytest pip
+conda install $QUIET pytest pip
 
 export PIP_INSTALL='pip install'
 
@@ -104,15 +110,15 @@ fi
 # NUMPY
 if [[ $NUMPY_VERSION == dev* ]]; then
     # Install at the bottom of this script
-    export CONDA_INSTALL="conda install -q python=$PYTHON_VERSION"
+    export CONDA_INSTALL="conda install $QUIET python=$PYTHON_VERSION"
 elif [[ $NUMPY_VERSION == stable ]]; then
-    conda install -q numpy
-    export CONDA_INSTALL="conda install -q python=$PYTHON_VERSION"
+    conda install $QUIET numpy
+    export CONDA_INSTALL="conda install $QUIET python=$PYTHON_VERSION"
 elif [[ ! -z $NUMPY_VERSION ]]; then
-    conda install -q numpy=$NUMPY_VERSION
-    export CONDA_INSTALL="conda install -q python=$PYTHON_VERSION numpy=$NUMPY_VERSION"
+    conda install $QUIET numpy=$NUMPY_VERSION
+    export CONDA_INSTALL="conda install $QUIET python=$PYTHON_VERSION numpy=$NUMPY_VERSION"
 else
-    export CONDA_INSTALL="conda install -q python=$PYTHON_VERSION"
+    export CONDA_INSTALL="conda install $QUIET python=$PYTHON_VERSION"
 fi
 
 # ASTROPY
@@ -170,7 +176,7 @@ fi
 # would override Numpy dev.
 
 if [[ $NUMPY_VERSION == dev* ]]; then
-    conda install -q Cython
+    conda install $QUIET Cython
     $PIP_INSTALL git+http://github.com/numpy/numpy.git#egg=numpy --upgrade
 fi
 

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -64,7 +64,7 @@ fi
 if [[ ! -z $CONDA_DEPENDENCIES ]]; then
     pin_file=$HOME/miniconda/envs/test/conda-meta/pinned
     echo $CONDA_DEPENDENCIES | awk '{print tolower($0)}' | tr " " "\n" | \
-        sed -E -e 's|([a-z]+)([=><!])|\1 \2|g' -e 's| =([0-9])| ==\1|g' > $pin_file
+        sed -E -e 's|([a-z0-9]+)([=><!])|\1 \2|g' -e 's| =([0-9])| ==\1|g' > $pin_file
 
     if [[ $DEBUG == True ]]; then
         cat $pin_file


### PR DESCRIPTION
- we should handle alphanumeric package names when pinning the versions
- fixing #52 by adding ``*`` to the end of all lines with ``==`` in the pin file
- addressing #50 with building the ``-q`` conda flag into the $DEBUG variable


