### PR TITLE
Pin matplotlib to <= 1.5.0

### DIFF
--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -158,7 +158,7 @@ fi
 if [[ $SETUP_CMD == build_sphinx* ]] || [[ $SETUP_CMD == build_docs* ]]; then
     # TODO: remove pinned matplotlib version once
     # https://github.com/matplotlib/matplotlib/issues/5836 is fixed
-    $CONDA_INSTALL Sphinx "matplotlib<=1.5.1"
+    $CONDA_INSTALL Sphinx "matplotlib<=1.5.0"
 fi
 
 # COVERAGE DEPENDENCIES


### PR DESCRIPTION
The `photutils` sphinx test is failing again because `matplotlib 1.5.1` is being installed:
https://travis-ci.org/astropy/photutils/jobs/105487931