### PR TITLE
Updating the pinning of matplotlib version for docs builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ matrix:
 
         # This is a broken test at the moment, as we manually require
         # mpl<=1.5.0 for sphinx. Once that requirement is gone this and the
-        # next two test2 can be merged together.
+        # next three tests can be merged together.
         - os: linux
           env: SETUP_CMD='build_sphinx' CONDA_DEPENDENCIES='matplotlib=1.5.0 sphinx'
                MATPLOTLIB_VERSION=1.5.1 DEBUG=True
@@ -59,6 +59,10 @@ matrix:
           env: SETUP_CMD='build_sphinx'
                MATPLOTLIB_VERSION=1.4 DEBUG=True
                TEST_CMD='python -c "import matplotlib; assert matplotlib.__version__=="\""1.4.3"\"'
+
+        - os: linux
+          env: SETUP_CMD='build_sphinx' DEBUG=True
+               TEST_CMD='python -c "import matplotlib; assert matplotlib.__version__!="\""1.5.1"\"'
 
         - os: linux
           env: SETUP_CMD='test' CONDA_DEPENDENCIES='matplotlib=1.5.0 sphinx'

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,11 +49,16 @@ matrix:
 
         # This is a broken test at the moment, as we manually require
         # mpl<=1.5.0 for sphinx. Once that requirement is gone this and the
-        # next test can be merged together.
+        # next two test2 can be merged together.
         - os: linux
           env: SETUP_CMD='build_sphinx' CONDA_DEPENDENCIES='matplotlib=1.5.0 sphinx'
                MATPLOTLIB_VERSION=1.5.1 DEBUG=True
                TEST_CMD='python -c "import matplotlib; assert matplotlib.__version__=="\""1.5.0"\"'
+
+        - os: linux
+          env: SETUP_CMD='build_sphinx'
+               MATPLOTLIB_VERSION=1.4 DEBUG=True
+               TEST_CMD='python -c "import matplotlib; assert matplotlib.__version__=="\""1.4.3"\"'
 
         - os: linux
           env: SETUP_CMD='test' CONDA_DEPENDENCIES='matplotlib=1.5.0 sphinx'

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -137,8 +137,25 @@ fi
 # DOCUMENTATION DEPENDENCIES
 # build_sphinx needs sphinx and matplotlib (for plot_directive).
 if [[ $SETUP_CMD == build_sphinx* ]] || [[ $SETUP_CMD == build_docs* ]]; then
+    # Check whether there are any version setting env variables, pin them if
+    # there are (only need to deal with the case when they aren't listed in
+    # CONDA_DEPENDENCIES, otherwise this was already dealt with)
+
+    pin_file=$HOME/miniconda/envs/test/conda-meta/pinned
+    if [[ ! -z $MATPLOTLIB_VERSION ]]; then
+        if [[ -z $(grep matplotlib $pin_file) ]]; then
+            echo "matplotlib ${MATPLOTLIB_VERSION}*" >> $pin_file
+        fi
+    fi
+    if [[ ! -z $SPHINX_VERSION ]]; then
+        if [[ -z $(grep sphinx $pin_file) ]]; then
+            echo "matplotlib ${SPHINX_VERSION}*" >> $pin_file
+        fi
+    fi
+
     # TODO: remove this pinned matplotlib version once
     # https://github.com/matplotlib/matplotlib/issues/5836 is fixed
+
     if [[ ! -z $pin_file ]]; then
         if [[ -z $(grep matplotlib $pin_file) ]]; then
             echo "matplotlib !=1.5.1" >> $pin_file
@@ -148,10 +165,14 @@ if [[ $SETUP_CMD == build_sphinx* ]] || [[ $SETUP_CMD == build_docs* ]]; then
             mv /tmp/pin_file_temp $pin_file
         fi
     else
-        echo "matplotlib !=1.5.1" > $HOME/miniconda/envs/test/conda-meta/pinned
+        echo "matplotlib !=1.5.1" >> $pin_file
     fi
 
-    $CONDA_INSTALL Sphinx matplotlib
+    if [[ $DEBUG == True ]]; then
+        cat $pin_file
+    fi
+
+    $CONDA_INSTALL sphinx matplotlib
 fi
 
 # ADDITIONAL DEPENDENCIES (can include optionals, too)

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -160,8 +160,13 @@ if [[ $SETUP_CMD == build_sphinx* ]] || [[ $SETUP_CMD == build_docs* ]]; then
         if [[ -z $(grep matplotlib $pin_file) ]]; then
             echo "matplotlib !=1.5.1" >> $pin_file
         else
-            awk '{if ($1 == "matplotlib") print "matplotlib "$2",!=1.5.1";
-              else print $0}' $pin_file > /tmp/pin_file_temp
+            echo "Due to a matplotlib issue (#5836), the version for the
+            sphinx builds needs to be !=1.5.1. This may override the version
+            number specified in $MATPLOTLIB_VERSION"
+            awk  '{if ($1 == "matplotlib")
+                       if ($2 == "1.5.1*") print "matplotlib !=1.5.1";
+                       else print "matplotlib "$2",!=1.5.1";
+                   else print $0}' $pin_file > /tmp/pin_file_temp
             mv /tmp/pin_file_temp $pin_file
         fi
     else

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -141,14 +141,14 @@ if [[ $SETUP_CMD == build_sphinx* ]] || [[ $SETUP_CMD == build_docs* ]]; then
     # https://github.com/matplotlib/matplotlib/issues/5836 is fixed
     if [[ ! -z $pin_file ]]; then
         if [[ -z $(grep matplotlib $pin_file) ]]; then
-            echo "matplotlib <=1.5.0" >> $pin_file
+            echo "matplotlib !=1.5.1" >> $pin_file
         else
-            awk '{if ($1 == "matplotlib") print "matplotlib <=1.5.0";
+            awk '{if ($1 == "matplotlib") print "matplotlib !=1.5.1";
               else print $0}' $pin_file > /tmp/pin_file_temp
             mv /tmp/pin_file_temp $pin_file
         fi
     else
-        echo "matplotlib <=1.5.0" > $HOME/miniconda/envs/test/conda-meta/pinned
+        echo "matplotlib !=1.5.1" > $HOME/miniconda/envs/test/conda-meta/pinned
     fi
 
     $CONDA_INSTALL Sphinx matplotlib

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -143,7 +143,7 @@ if [[ $SETUP_CMD == build_sphinx* ]] || [[ $SETUP_CMD == build_docs* ]]; then
         if [[ -z $(grep matplotlib $pin_file) ]]; then
             echo "matplotlib !=1.5.1" >> $pin_file
         else
-            awk '{if ($1 == "matplotlib") print "matplotlib !=1.5.1";
+            awk '{if ($1 == "matplotlib") print "matplotlib "$2",!=1.5.1";
               else print $0}' $pin_file > /tmp/pin_file_temp
             mv /tmp/pin_file_temp $pin_file
         fi


### PR DESCRIPTION
I think the current way of hard-wiring the version to <=1.5.0 for mpl for all the docs builds isn't the right way to do it. 
E.g. it will potentially cause failures for packages that require a version of 1.4.x (as it's overrides everything, and thus 1.5.0 will be installed for those packages, too even though 1.4.x will be perfectly fine for the docs build).

Also as a somewhat separate fix, this PR makes sure that SPHINX_VERSION and MATPLOTLIB_VERSION are taken into account for the docs builds, even when they are not listed as a conda dependency (thus their versions are not pinned).

@astrofrog - Could you please review it?