### PR TITLE
Handling of pre-releases of numpy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ matrix:
         # release is available for numpy on pypi, otherwise it should pass
         - os: linux
           env: SETUP_CMD='test' NUMPY_VERSION=pre
-               CONDA_DEPENDENCIES='scipy'
+               CONDA_DEPENDENCIES='scipy' DEBUG=True
 
         - os: linux
           env: SETUP_CMD='build_sphinx' CONDA_DEPENDENCIES='matplotlib<=1.5.0'

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,12 @@ matrix:
           env: SETUP_CMD='test' NUMPY_VERSION=dev
                CONDA_DEPENDENCIES='scipy'
 
+        # The pre build only should run to the testing phase if a pre
+        # release is available for numpy on pypi, otherwise it should pass
+        - os: linux
+          env: SETUP_CMD='test' NUMPY_VERSION=pre
+               CONDA_DEPENDENCIES='scipy'
+
         - os: linux
           env: SETUP_CMD='build_sphinx' CONDA_DEPENDENCIES='matplotlib<=1.5.0'
                DEBUG=True

--- a/README.md
+++ b/README.md
@@ -62,7 +62,9 @@ Following this, various dependencies are installed depending on the following en
 * ``$NUMPY_VERSION``: if set to ``dev`` or ``development``, the latest
   developer version of Numpy is installed along with Cython. If set to a
   version number, that version is installed. If set to ``stable``, install
-  the latest stable version of Numpy.
+  the latest stable version of Numpy. If set to ``prerelease``, the
+  pre-release version of Numpy gets installed if there is any, otherwise the
+  build exits and passes on travis without running the tests.
 
 * ``$ASTROPY_VERSION``: if set to ``dev`` or ``development``, the latest
   developer version of Astrop is installed, along with Cython and jinja2,

--- a/test_env.py
+++ b/test_env.py
@@ -43,12 +43,15 @@ def test_numpy():
         os_numpy_version = os.environ['NUMPY_VERSION'].lower()
         if 'dev' in os_numpy_version:
             assert 'dev' in numpy.__version__
+        elif 'pre' in os_numpy_version:
+            assert 'pre' in numpy.__version__
         else:
             if 'stable' in os_numpy_version:
                 assert numpy.__version__.startswith(LATEST_NUMPY_STABLE)
             else:
                 assert numpy.__version__.startswith(os_numpy_version)
             assert 'dev' not in numpy.__version__
+            assert 'pre' not in numpy.__version__
 
 
 def test_astropy():

--- a/test_env.py
+++ b/test_env.py
@@ -40,18 +40,18 @@ def test_python_version():
 def test_numpy():
     if 'NUMPY_VERSION' in os.environ:
         import numpy
+        np_version = numpy.__version__
         os_numpy_version = os.environ['NUMPY_VERSION'].lower()
         if 'dev' in os_numpy_version:
-            assert 'dev' in numpy.__version__
+            assert 'dev' in np_version
         elif 'pre' in os_numpy_version:
-            assert 'pre' in numpy.__version__
+            assert re.match("[0-9.]*[0-9](a[0-9]|b[0-9]|rc[0-9])", np_version)
         else:
             if 'stable' in os_numpy_version:
-                assert numpy.__version__.startswith(LATEST_NUMPY_STABLE)
+                assert np_version.startswith(LATEST_NUMPY_STABLE)
             else:
-                assert numpy.__version__.startswith(os_numpy_version)
-            assert 'dev' not in numpy.__version__
-            assert 'pre' not in numpy.__version__
+                assert np_version.startswith(os_numpy_version)
+            assert re.match("^[0-9]+\.[0-9]+\.[0-9]", np_version)
 
 
 def test_astropy():

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -123,7 +123,7 @@ elif [[ $NUMPY_VERSION == stable ]]; then
 elif [[ $NUMPY_VERSION == pre ]]; then
     conda install $QUIET numpy
     export CONDA_INSTALL="conda install $QUIET python=$PYTHON_VERSION"
-    if [[ -z $(pip list -o --pre |grep numpy) ]]; then
+    if [[ -z $(pip list -o --pre | grep numpy | grep pre) ]]; then
         exit
     fi
 elif [[ ! -z $NUMPY_VERSION ]]; then

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -124,7 +124,7 @@ elif [[ $NUMPY_VERSION == pre* ]]; then
     conda install $QUIET numpy
     export CONDA_INSTALL="conda install $QUIET python=$PYTHON_VERSION"
     if [[ -z $(pip list -o --pre | grep numpy | \
-        grep -E "pre|[0-9]rc[0-9]|[0-9][ab][0-9]") ]]; then
+            grep -E "[0-9]rc[0-9]|[0-9][ab][0-9]") ]]; then
         exit
     fi
 elif [[ ! -z $NUMPY_VERSION ]]; then

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -120,10 +120,11 @@ if [[ $NUMPY_VERSION == dev* ]]; then
 elif [[ $NUMPY_VERSION == stable ]]; then
     conda install $QUIET numpy
     export CONDA_INSTALL="conda install $QUIET python=$PYTHON_VERSION"
-elif [[ $NUMPY_VERSION == pre ]]; then
+elif [[ $NUMPY_VERSION == pre* ]]; then
     conda install $QUIET numpy
     export CONDA_INSTALL="conda install $QUIET python=$PYTHON_VERSION"
-    if [[ -z $(pip list -o --pre | grep numpy | grep pre) ]]; then
+    if [[ -z $(pip list -o --pre | grep numpy | \
+        grep -E "pre|[0-9]rc[0-9]|[0-9][ab][0-9]") ]]; then
         exit
     fi
 elif [[ ! -z $NUMPY_VERSION ]]; then
@@ -219,7 +220,7 @@ if [[ $NUMPY_VERSION == dev* ]]; then
     $PIP_INSTALL git+http://github.com/numpy/numpy.git#egg=numpy --upgrade --no-deps
 fi
 
-if [[ $NUMPY_VERSION == pre ]]; then
+if [[ $NUMPY_VERSION == pre* ]]; then
     $PIP_INSTALL --pre --upgrade numpy
 fi
 

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -109,10 +109,10 @@ fi
 
 # NUMPY
 if [[ $NUMPY_VERSION == dev* ]]; then
-    # We install nomkl here to make sure that Numpy and Scipy versions 
-    # installed subsequently don't depend on the MKL. If we don't do this, then 
-    # we run into issues when we install the developer version of Numpy 
-    # because it is then not compiled against the MKL, and one runs into issues 
+    # We install nomkl here to make sure that Numpy and Scipy versions
+    # installed subsequently don't depend on the MKL. If we don't do this, then
+    # we run into issues when we install the developer version of Numpy
+    # because it is then not compiled against the MKL, and one runs into issues
     # if Scipy *is* still compiled against the MKL.
     conda install $QUIET nomkl
     # We then install Numpy itself at the bottom of this script
@@ -120,6 +120,12 @@ if [[ $NUMPY_VERSION == dev* ]]; then
 elif [[ $NUMPY_VERSION == stable ]]; then
     conda install $QUIET numpy
     export CONDA_INSTALL="conda install $QUIET python=$PYTHON_VERSION"
+elif [[ $NUMPY_VERSION == pre ]]; then
+    conda install $QUIET numpy
+    export CONDA_INSTALL="conda install $QUIET python=$PYTHON_VERSION"
+    if [[ -z $(pip list -o --pre |grep numpy) ]]; then
+        exit
+    fi
 elif [[ ! -z $NUMPY_VERSION ]]; then
     conda install $QUIET numpy=$NUMPY_VERSION
     export CONDA_INSTALL="conda install $QUIET python=$PYTHON_VERSION numpy=$NUMPY_VERSION"
@@ -202,15 +208,19 @@ if [[ $SETUP_CMD == *open-files* ]]; then
     $CONDA_INSTALL psutil
 fi
 
-# NUMPY DEV
+# NUMPY DEV and PRE
 
 # We now install Numpy dev - this has to be done last, otherwise conda might
 # install a stable version of Numpy as a dependency to another package, which
-# would override Numpy dev.
+# would override Numpy dev or pre.
 
 if [[ $NUMPY_VERSION == dev* ]]; then
     conda install $QUIET Cython
     $PIP_INSTALL git+http://github.com/numpy/numpy.git#egg=numpy --upgrade --no-deps
+fi
+
+if [[ $NUMPY_VERSION == pre ]]; then
+    $PIP_INSTALL --pre --upgrade numpy
 fi
 
 # ASTROPY DEV


### PR DESCRIPTION
If a pre release is available install it and run the tests, otherwise abort the build (which would result a pass on travis).

It definitely works when no pre release is available, but I'm not 100% sure it would pick up the pre release as the strings may need some adjustments.  Now it's assumed "pre" is in the name of the pre-release.

@mhvk: is this what you've thought of?