### PR TITLE
PIP_DEPENDENCIES should be installed after dev versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,9 +30,11 @@ env:
 matrix:
     include:
 
-        # Starting with the dev versions as they take the longest to run
+        # Starting with the dev versions as they take the longest to run. We 
+        # deliberately test with Numpy 1.9 to check that installing Astropy dev 
+        # doesn't upgrade Numpy.
         - os: linux
-          env: SETUP_CMD='test' NUMPY_VERSION=1.10 ASTROPY_VERSION=dev
+          env: SETUP_CMD='test' NUMPY_VERSION=1.9 ASTROPY_VERSION=dev
 
         # For the Numpy dev build, we also specify a conda package that depends
         # on Numpy to make sure that Numpy dev is used (because conda will also

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -43,6 +43,12 @@ environment:
         NUMPY_VERSION: "1.10"
         ASTROPY_VERSION: "lts"
 
+      - PYTHON_VERSION: "3.5"
+        NUMPY_VERSION: "1.9"
+        ASTROPY_VERSION: "1.0"
+        CONDA_DEPENDENCIES: "matplotlib h5py"
+        PIP_DEPENDENCIES: "astrodendro"
+
 platform:
     -x64
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,9 +16,6 @@ environment:
 
       - PYTHON_VERSION: "2.7"
 
-      - PYTHON_VERSION: "2.7"
-        NUMPY_VERSION: "stable"
-
         # For the Numpy dev build, we also specify a conda package that depends
         # on Numpy to make sure that Numpy dev is used (because conda will also
         # install Numpy stable)
@@ -34,10 +31,6 @@ environment:
       - PYTHON_VERSION: "3.5"
         NUMPY_VERSION: "1.9"
         ASTROPY_VERSION: "development"
-
-      - PYTHON_VERSION: "3.5"
-        NUMPY_VERSION: "1.10"
-        ASTROPY_VERSION: "stable"
 
       - PYTHON_VERSION: "3.5"
         NUMPY_VERSION: "1.10"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -44,8 +44,8 @@ environment:
         ASTROPY_VERSION: "lts"
 
       - PYTHON_VERSION: "3.5"
-        NUMPY_VERSION: "1.9"
-        ASTROPY_VERSION: "1.0"
+        NUMPY_VERSION: "stable"
+        ASTROPY_VERSION: "stable"
         CONDA_DEPENDENCIES: "matplotlib h5py"
         PIP_DEPENDENCIES: "astrodendro"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,8 +29,10 @@ environment:
       - PYTHON_VERSION: "3.4"
         NUMPY_VERSION: "1.9"
 
+        # We deliberately test with Numpy 1.9 to check that installing Astropy 
+        # dev doesn't upgrade Numpy.
       - PYTHON_VERSION: "3.5"
-        NUMPY_VERSION: "1.10"
+        NUMPY_VERSION: "1.9"
         ASTROPY_VERSION: "development"
 
       - PYTHON_VERSION: "3.5"

--- a/appveyor/install-miniconda.ps1
+++ b/appveyor/install-miniconda.ps1
@@ -138,3 +138,15 @@ if ($env:NUMPY_VERSION -match "dev") {
 if ($env:ASTROPY_VERSION -match "dev") {
    Invoke-Expression "${env:CMD_IN_ENV} pip install git+http://github.com/astropy/astropy.git#egg=astropy --upgrade --no-deps"
 }
+
+# We finally install the dependencies listed in PIP_DEPENDENCIES. We do this
+# after installing the Numpy versions of Numpy or Astropy. If we didn't do this,
+# then calling pip earlier could result in the stable version of astropy getting
+# installed, and then overritten later by the dev version (which would waste
+# build time)
+
+if ($env:PIP_DEPENDENCIES) {
+    pip install $PIP_DEPENDENCIES $PIP_FLAGS
+}
+
+

--- a/appveyor/install-miniconda.ps1
+++ b/appveyor/install-miniconda.ps1
@@ -145,6 +145,18 @@ if ($env:ASTROPY_VERSION -match "dev") {
 # installed, and then overritten later by the dev version (which would waste
 # build time)
 
+if ($env:PIP_FLAGS) {
+    $PIP_FLAGS = $env:PIP_FLAGS
+} else {
+    $PIP_FLAGS = ""
+}
+
+if ($env:PIP_DEPENDENCIES) {
+    $PIP_DEPENDENCIES = $env:PIP_DEPENDENCIES
+} else {
+    $PIP_DEPENDENCIES = ""
+}
+
 if ($env:PIP_DEPENDENCIES) {
     pip install $PIP_DEPENDENCIES $PIP_FLAGS
 }

--- a/appveyor/install-miniconda.ps1
+++ b/appveyor/install-miniconda.ps1
@@ -130,9 +130,11 @@ conda install -n test -q pytest $NUMPY_OPTION $ASTROPY_OPTION $CONDA_DEPENDENCIE
 
 # Check whether the developer version of Numpy is required and if yes install it
 if ($env:NUMPY_VERSION -match "dev") {
-   Invoke-Expression "${env:CMD_IN_ENV} pip install git+http://github.com/numpy/numpy.git#egg=numpy --upgrade"
+   Invoke-Expression "${env:CMD_IN_ENV} pip install git+http://github.com/numpy/numpy.git#egg=numpy --upgrade --no-deps"
 }
-# Check whether the developer version of Astropy is required and if yes install it
+
+# Check whether the developer version of Astropy is required and if yes install
+# it. We need to include --no-deps to make sure that Numpy doesn't get upgraded.
 if ($env:ASTROPY_VERSION -match "dev") {
-   Invoke-Expression "${env:CMD_IN_ENV} pip install git+http://github.com/astropy/astropy.git#egg=astropy --upgrade"
+   Invoke-Expression "${env:CMD_IN_ENV} pip install git+http://github.com/astropy/astropy.git#egg=astropy --upgrade --no-deps"
 }

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -186,10 +186,6 @@ if [[ ! -z $CONDA_DEPENDENCIES ]]; then
     $CONDA_INSTALL $CONDA_DEPENDENCIES $CONDA_DEPENDENCIES_FLAGS
 fi
 
-if [[ ! -z $PIP_DEPENDENCIES ]]; then
-    $PIP_INSTALL $PIP_DEPENDENCIES $PIP_DEPENDENCIES_FLAGS
-fi
-
 # PARALLEL BUILDS
 if [[ $SETUP_CMD == *parallel* ]]; then
     $PIP_INSTALL pytest-xdist
@@ -238,5 +234,18 @@ if [[ $DEBUG == True ]]; then
     conda install -n root _license
     conda info -a
 fi
+
+# PIP DEPENDENCIES
+
+# We finally install the dependencies listed in PIP_DEPENDENCIES. We do this
+# after installing the Numpy versions of Numpy or Astropy. If we didn't do this,
+# then calling pip earlier could result in the stable version of astropy getting
+# installed, and then overritten later by the dev version (which would waste
+# build time)
+
+if [[ ! -z $PIP_DEPENDENCIES ]]; then
+    $PIP_INSTALL $PIP_DEPENDENCIES $PIP_DEPENDENCIES_FLAGS
+fi
+
 
 set +x

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -217,7 +217,7 @@ fi
 
 if [[ $NUMPY_VERSION == dev* ]]; then
     conda install $QUIET Cython
-    $PIP_INSTALL git+http://github.com/numpy/numpy.git#egg=numpy --upgrade
+    $PIP_INSTALL git+http://github.com/numpy/numpy.git#egg=numpy --upgrade --no-deps
 fi
 
 # ASTROPY DEV
@@ -225,11 +225,12 @@ fi
 # We now install Astropy dev - this has to be done last, otherwise conda might
 # install a stable version of Astropy as a dependency to another package, which
 # would override Astropy dev. Also, if we are installing Numpy dev, we need to
-# compile Astropy dev against Numpy dev.
+# compile Astropy dev against Numpy dev. We need to include --no-deps to make
+# sure that Numpy doesn't get upgraded.
 
 if [[ $ASTROPY_VERSION == dev* ]]; then
     $CONDA_INSTALL Cython jinja2
-    $PIP_INSTALL git+http://github.com/astropy/astropy.git#egg=astropy --upgrade
+    $PIP_INSTALL git+http://github.com/astropy/astropy.git#egg=astropy --upgrade --no-deps
 fi
 
 if [[ $DEBUG == True ]]; then


### PR DESCRIPTION
While it was correct to move the installation of dev versions of packages after ``CONDA_DEPENDENCIES``, I think they should be installed before ``PIP_DEPENDENCIES``, otherwise pip will waste time installing e.g. a stable version of astropy, only to then replace it later with the dev version. With pip, there is no risk that pip will override the dev version though (unlike conda)