### PR TITLE
Fixing one more corner case for mpl pinning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ matrix:
 
         # This is a broken test at the moment, as we manually require
         # mpl<=1.5.0 for sphinx. Once that requirement is gone this and the
-        # next three tests can be merged together.
+        # next four tests can be merged together.
         - os: linux
           env: SETUP_CMD='build_sphinx' CONDA_DEPENDENCIES='matplotlib=1.5.0 sphinx'
                MATPLOTLIB_VERSION=1.5.1 DEBUG=True
@@ -62,6 +62,10 @@ matrix:
 
         - os: linux
           env: SETUP_CMD='build_sphinx' DEBUG=True
+               TEST_CMD='python -c "import matplotlib; assert matplotlib.__version__!="\""1.5.1"\"'
+
+        - os: linux
+          env: SETUP_CMD='build_sphinx' DEBUG=True CONDA_DEPENDENCIES='matplotlib'
                TEST_CMD='python -c "import matplotlib; assert matplotlib.__version__!="\""1.5.1"\"'
 
         - os: linux

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -164,7 +164,8 @@ if [[ $SETUP_CMD == build_sphinx* ]] || [[ $SETUP_CMD == build_docs* ]]; then
             sphinx builds needs to be !=1.5.1. This may override the version
             number specified in $MATPLOTLIB_VERSION"
             awk  '{if ($1 == "matplotlib")
-                       if ($2 == "1.5.1*") print "matplotlib !=1.5.1";
+                       if ($2 == "1.5.1*" || NF == 1)
+                           print "matplotlib !=1.5.1";
                        else print "matplotlib "$2",!=1.5.1";
                    else print $0}' $pin_file > /tmp/pin_file_temp
             mv /tmp/pin_file_temp $pin_file


### PR DESCRIPTION
Fixing the case when mpl is listed as dependency but without version number (thus is listed in the pinfile, but without any restriction).