### PR TITLE
Possible fix for an additional mpl pinning issue

### DIFF
--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -164,7 +164,7 @@ if [[ $SETUP_CMD == build_sphinx* ]] || [[ $SETUP_CMD == build_docs* ]]; then
             sphinx builds needs to be !=1.5.1. This may override the version
             number specified in $MATPLOTLIB_VERSION"
             awk  '{if ($1 == "matplotlib")
-                       if ($2 == "1.5.1*" || NF == 1)
+                       if ($2 == "1.5.1*" || NF == 1 || $2 == "")
                            print "matplotlib !=1.5.1";
                        else print "matplotlib "$2",!=1.5.1";
                    else print $0}' $pin_file > /tmp/pin_file_temp


### PR DESCRIPTION
This build was just pointed out to me by @aphearin : https://travis-ci.org/astropy/halotools/jobs/106553030 . The most recent change that led to this seems to be #61 - @bsipocz, do you have any idea why this is happening?  It looks like for some reason we're hitting https://github.com/astropy/ci-helpers/blob/master/travis/setup_dependencies_common.sh#L169 instead of the line above it... incorrectly in this case.  

This  PR is a speculative attempt at how that might be fixed, but I'm not really sure how the pinning stuff works, and also not sure what the best way is to *test* this machinery.  So any hints from @bsipocz would be appreciated.