### PR TITLE
Issue with Numpy dev now that the conda Scipy/Numpy packages are compiled against MKL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,10 @@ matrix:
 
         # For the Numpy dev build, we also specify a conda package that depends
         # on Numpy to make sure that Numpy dev is used (because conda will also
-        # install Numpy stable)
+        # install Numpy stable). It's also important to include scipy here to
+        # make sure that scipy routines still work correctly, because if we
+        # aren't careful, we can end up with issues with the math kernel 
+        # library.
 
         - os: linux
           env: SETUP_CMD='test' NUMPY_VERSION=dev

--- a/test_env.py
+++ b/test_env.py
@@ -117,6 +117,29 @@ def test_pip_flags():
         pytest.skip()
 
 
+def test_regression_mkl():
+
+    # Regression test to make sure that if the developer version of Numpy is
+    # used, scipy still works correctly. At some point, the conda packages for
+    # Numpy and Scipy were compiled with the MKL, and this then led to issues
+    # if installing Numpy dev with pip without making sure it was also using
+    # the MKL. The solution is to simply make sure that we install the
+    # ``nomkl`` conda pacakge when installing the developer version of Numpy.
+
+    if os.environ.get('NUMPY_VERSION', '') == 'dev':
+
+        try:
+            import scipy
+        except ImportError:
+            pytest.skip()
+
+        import numpy as np
+        from scipy.linalg import inv
+
+        x = np.random.random((3,3))
+        inv(x)
+
+
 if __name__ == '__main__':
     import pytest
     pytest.main(__file__)

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -109,7 +109,13 @@ fi
 
 # NUMPY
 if [[ $NUMPY_VERSION == dev* ]]; then
-    # Install at the bottom of this script
+    # We install nomkl here to make sure that Numpy and Scipy versions 
+    # installed subsequently don't depend on the MKL. If we don't do this, then 
+    # we run into issues when we install the developer version of Numpy 
+    # because it is then not compiled against the MKL, and one runs into issues 
+    # if Scipy *is* still compiled against the MKL.
+    conda install $QUIET nomkl
+    # We then install Numpy itself at the bottom of this script
     export CONDA_INSTALL="conda install $QUIET python=$PYTHON_VERSION"
 elif [[ $NUMPY_VERSION == stable ]]; then
     conda install $QUIET numpy


### PR DESCRIPTION
To reproduce (on Linux):

```
conda create -n test python=2.7 scipy cython
source activate test
pip install https://github.com/numpy/numpy/archive/master.zip
```

then run:

```python
import numpy as np
from scipy.linalg import inv

x = np.random.random((3,3))
inv(x)
```

The error is:

```
Intel MKL FATAL ERROR: Cannot load libmkl_avx.so or libmkl_def.so.
```

This repo shows a minimal failing example with ci-helpers:

https://github.com/astrofrog/debug-mkl
https://travis-ci.org/astrofrog/debug-mkl/builds/108036541

There are two possible solutions:

* As a workaround, pin Scipy to 0.15 to prevent 0.17 from getting installed
* The proper solution is probably to git clone the Numpy repository, and edit the ``site.cfg`` file to point to the conda MKL library, and make sure we use that