### PR TITLE
Simplifying appveyor matrix

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,7 +21,8 @@ environment:
         # install Numpy stable)
       - PYTHON_VERSION: "2.7"
         NUMPY_VERSION: "development"
-        CONDA_DEPENDENCIES: "scipy"
+        CONDA_DEPENDENCIES: "scipy glymur"
+        CONDA_CHANNELS: "sunpy"
 
       - PYTHON_VERSION: "3.4"
         NUMPY_VERSION: "1.9"
@@ -39,9 +40,9 @@ environment:
       - PYTHON_VERSION: "3.5"
         NUMPY_VERSION: "stable"
         ASTROPY_VERSION: "stable"
-        CONDA_DEPENDENCIES: "matplotlib h5py pyqt5"
+        CONDA_DEPENDENCIES: "matplotlib h5py"
         PIP_DEPENDENCIES: "astrodendro"
-        CONDA_CHANNELS: "astropy-ci-extras astrofrog"
+
 
 
 platform:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,7 @@ environment:
       - PYTHON_VERSION: "3.4"
         NUMPY_VERSION: "1.9"
 
-        # We deliberately test with Numpy 1.9 to check that installing Astropy 
+        # We deliberately test with Numpy 1.9 to check that installing Astropy
         # dev doesn't upgrade Numpy.
       - PYTHON_VERSION: "3.5"
         NUMPY_VERSION: "1.9"
@@ -39,14 +39,9 @@ environment:
       - PYTHON_VERSION: "3.5"
         NUMPY_VERSION: "stable"
         ASTROPY_VERSION: "stable"
-        CONDA_DEPENDENCIES: "matplotlib h5py"
+        CONDA_DEPENDENCIES: "matplotlib h5py pyqt5"
         PIP_DEPENDENCIES: "astrodendro"
-
-      - PYTHON_VERSION: "2.7"
-        NUMPY_VERSION: "stable"
-        ASTROPY_VERSION: "stable"
-        CONDA_DEPENDENCIES: "glymur sunpy"
-        CONDA_CHANNELS: "astropy astropy-ci-extras sunpy"
+        CONDA_CHANNELS: "astropy-ci-extras astrofrog"
 
 
 platform:


### PR DESCRIPTION
Removing unnecessary build, and adding the CONDA_CHANNELS testing into an already existing build to save up a bit of build time.
