### PR TITLE
Adding the openastronomy conda channel to the default channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,11 @@ install:
 
 This does the following:
 
-- Set up Miniconda
-- Set up the PATH appropriately
-- Set up a conda environment named 'test' and switch to it
-- Set the ``always_yes`` config option for conda to ``true`` so that you don't need to include ``--yes``
-- Register the specified channels, or if not stated the ``astropy`` and ``astropy-ci-extras`` channels
+- Set up Miniconda.
+- Set up the PATH appropriately.
+- Set up a conda environment named 'test' and switch to it.
+- Set the ``always_yes`` config option for conda to ``true`` so that you don't need to include ``--yes``.
+- Register the specified channels, or if not stated the ``astropy``, ``astropy-ci-extras``, and ``openastronomy`` channels.
 - ``export PYTHONIOENCODING=UTF8``
 
 Following this, various dependencies are installed depending on the following environment variables
@@ -92,7 +92,8 @@ Following this, various dependencies are installed depending on the following en
   installing ``PIP_DEPENDENCIES``
 
 * ``$CONDA_CHANNELS``: this should be a space-separated string of conda
-  channel names, and defaults to ``astropy`` and ``astropy-ci-extras``.
+  channel names, and defaults to ``astropy``, ``astropy-ci-extras``, and
+  ``openastronomy``.
 
 * ``$DEBUG``: if `True` this turns on the shell debug mode in the install
   scripts, and provides information on the current conda install and
@@ -152,11 +153,11 @@ install:
 
 This does the following:
 
-- Set up Miniconda
-- Set up the PATH appropriately
-- Set up a conda environment named 'test' and switch to it
-- Set the ``always_yes`` config option for conda to ``true`` so that you don't need to include ``--yes``
-- Register the specified channels, or if not stated the ``astropy`` and ``astropy-ci-extras`` channels
+- Set up Miniconda.
+- Set up the PATH appropriately.
+- Set up a conda environment named 'test' and switch to it.
+- Set the ``always_yes`` config option for conda to ``true`` so that you don't need to include ``--yes``.
+- Register the specified channels, or if not stated the ``astropy``, ``astropy-ci-extras``, and ``openastronomy`` channels.
 
 Following this, various dependencies are installed depending on the following environment variables
 
@@ -177,7 +178,8 @@ Following this, various dependencies are installed depending on the following en
   names that will be installed with conda.
 
 * ``$CONDA_CHANNELS``: this should be a space-separated string of conda
-  channel names, and defaults to ``astropy`` and ``astropy-ci-extras``.
+  channel names, and defaults to ``astropy``, ``astropy-ci-extras``, and
+  ``openastronomy``.
 
 Details
 -------

--- a/appveyor/install-miniconda.ps1
+++ b/appveyor/install-miniconda.ps1
@@ -78,7 +78,7 @@ $env:PATH = "${env:PYTHON};${env:PYTHON}\Scripts;" + $env:PATH
 conda config --set always_yes true
 
 if (! $env:CONDA_CHANNELS) {
-   $CONDA_CHANNELS=@("astropy", "astropy-ci-extras")
+   $CONDA_CHANNELS=@("astropy", "astropy-ci-extras", "openastronomy")
 } else {
    $CONDA_CHANNELS=$env:CONDA_CHANNELS.split(" ")
 }

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -19,7 +19,7 @@ if [[ -z $ASTROPY_LTS_VERSION ]]; then
 fi
 
 if [[ -z $CONDA_CHANNELS ]]; then
-    CONDA_CHANNELS='astropy-ci-extras astropy'
+    CONDA_CHANNELS='astropy-ci-extras astropy openastronomy'
 fi
 
 if [[ -z $CONDA_DEPENDENCIES_FLAGS ]]; then


### PR DESCRIPTION
Maybe one or both of the others can be removed, as well?