### PR TITLE
Temporary fixing of sphinx version to be <1.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -81,8 +81,9 @@ matrix:
                TEST_CMD='python -c "import matplotlib; assert matplotlib.__version__!="\""1.5.1"\"'
 
         - os: linux
-          env: SETUP_CMD='build_sphinx' DEBUG=True CONDA_DEPENDENCIES='matplotlib'
-               TEST_CMD='python -c "import matplotlib; assert matplotlib.__version__!="\""1.5.1"\"'
+          env: SETUP_CMD='build_sphinx' SPHINX_VERSION=1.4.1 DEBUG=True
+               CONDA_DEPENDENCIES='matplotlib'
+               TEST_CMD='python -c "import sphinx; assert sphinx.__version__==\"1.4.1\"; import matplotlib; assert matplotlib.__version__!="\""1.5.1"\"'
 
         - os: linux
           env: SETUP_CMD='test' CONDA_DEPENDENCIES='matplotlib=1.5.0 sphinx'

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -174,7 +174,7 @@ if [[ $SETUP_CMD == build_sphinx* ]] || [[ $SETUP_CMD == build_docs* ]]; then
     fi
     if [[ ! -z $SPHINX_VERSION ]]; then
         if [[ -z $(grep sphinx $pin_file) ]]; then
-            echo "matplotlib ${SPHINX_VERSION}*" >> $pin_file
+            echo "sphinx ${SPHINX_VERSION}*" >> $pin_file
         fi
     fi
 

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -172,6 +172,15 @@ if [[ $SETUP_CMD == build_sphinx* ]] || [[ $SETUP_CMD == build_docs* ]]; then
             echo "matplotlib ${MATPLOTLIB_VERSION}*" >> $pin_file
         fi
     fi
+
+    # This is a temporary workaround of 2 warnings that appeared in the new
+    # 1.4 sphinx version, and that should be dealt with in
+    # astropy-helpers. This was we allow to override this version
+    # restriction by setting this variable in .travis.yml
+    if [[ -z $SPHINX_VERSION ]]; then
+        SPHINX_VERSION='<1.4'
+    fi
+
     if [[ ! -z $SPHINX_VERSION ]]; then
         if [[ -z $(grep sphinx $pin_file) ]]; then
             echo "sphinx ${SPHINX_VERSION}*" >> $pin_file


### PR DESCRIPTION
With the new 1.4 sphinx we run into 2 WARNINGS. This affects every package that uses astropy-helpers, thus I think it's sensible to add a requirement for the sphinx version to be ``<1.4`` here and not at the package level.
For packages that run the sphinx build without the ``-w`` option, and thus are insensitive of these warnings, there is an option to use the ``SPHINX_VERSION`` variable to override this limitation.

We can remove this once the issue is address in the helpers.

The warnings are:
```
WARNING: while setting up extension astropy_helpers.sphinx.ext.autodoc_enhancements: directive 'autoattribute' is already registered, it will be overridden
WARNING: sphinx.ext.pngmath has been deprecated. Please use sphinx.ext.imgmath instead.
```

@astrofrog - What do you think?