### PR TITLE
Fixing mpl font caching issue with the suggested workaround

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,27 +63,10 @@ matrix:
                DEBUG=True
                TEST_CMD='python -c "import matplotlib; assert matplotlib.__version__=="\""1.5.0"\"'
 
-        # This is a broken test at the moment, as we manually require
-        # mpl<=1.5.0 for sphinx. Once that requirement is gone this and the
-        # next four tests can be merged together.
-        - os: linux
-          env: SETUP_CMD='build_sphinx' CONDA_DEPENDENCIES='matplotlib=1.5.0 sphinx'
-               MATPLOTLIB_VERSION=1.5.1 DEBUG=True
-               TEST_CMD='python -c "import matplotlib; assert matplotlib.__version__=="\""1.5.0"\"'
-
-        - os: linux
-          env: SETUP_CMD='build_sphinx'
-               MATPLOTLIB_VERSION=1.4 DEBUG=True
-               TEST_CMD='python -c "import matplotlib; assert matplotlib.__version__=="\""1.4.3"\"'
-
-        - os: linux
-          env: SETUP_CMD='build_sphinx' DEBUG=True
-               TEST_CMD='python -c "import matplotlib; assert matplotlib.__version__!="\""1.5.1"\"'
-
         - os: linux
           env: SETUP_CMD='build_sphinx' SPHINX_VERSION=1.4.1 DEBUG=True
-               CONDA_DEPENDENCIES='matplotlib'
-               TEST_CMD='python -c "import sphinx; assert sphinx.__version__==\"1.4.1\"; import matplotlib; assert matplotlib.__version__!="\""1.5.1"\"'
+               MATPLOTLIB_VERSION=1.4 DEBUG=True
+               TEST_CMD='python -c "import sphinx; assert sphinx.__version__==\"1.4.1\"; import matplotlib; assert matplotlib.__version__=="\""1.4.3"\"'
 
         - os: linux
           env: SETUP_CMD='test' CONDA_DEPENDENCIES='matplotlib=1.5.0 sphinx'

--- a/test_env.py
+++ b/test_env.py
@@ -118,8 +118,8 @@ def test_open_files():
 
 
 def test_conda_flags():
-    if (os.environ.get('CONDA_DEPENDENCIES_FLAGS', '') == '--no-deps'
-        and os.environ.get('CONDA_DEPENDENCIES', '') == 'matplotlib'):
+    if (os.environ.get('CONDA_DEPENDENCIES_FLAGS', '') == '--no-deps' and
+            os.environ.get('CONDA_DEPENDENCIES', '') == 'matplotlib'):
         try:
             import numpy
         except:
@@ -157,10 +157,9 @@ def test_regression_mkl():
         import numpy as np
         from scipy.linalg import inv
 
-        x = np.random.random((3,3))
+        x = np.random.random((3, 3))
         inv(x)
 
 
 if __name__ == '__main__':
-    import pytest
     pytest.main(__file__)

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -317,6 +317,17 @@ if [[ $SETUP_CMD == *coverage* ]]; then
     $PIP_INSTALL coveralls
 fi
 
+
+# SPHINX BUILD MPL FONT CACHING WORKAROUND
+
+# This is required to avoid Sphinx build failures due to a warning that
+# comes from the mpl FontManager(). The workaround is to initialize the
+# cache before starting the tests/docs build. See details in
+# https://github.com/matplotlib/matplotlib/issues/5836
+
+python -c "import matplotlib.pyplot"
+
+
 # DEBUG INFO
 
 if [[ $DEBUG == True ]]; then

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -304,8 +304,9 @@ fi
 # cache before starting the tests/docs build. See details in
 # https://github.com/matplotlib/matplotlib/issues/5836
 
-python -c "import matplotlib.pyplot"
-
+if [[ $SETUP_CMD == build_sphinx* ]] || [[ $SETUP_CMD == build_docs* ]]; then
+    python -c "import matplotlib.pyplot"
+fi
 
 # DEBUG INFO
 

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -201,27 +201,6 @@ if [[ $SETUP_CMD == build_sphinx* ]] || [[ $SETUP_CMD == build_docs* ]]; then
         fi
     fi
 
-    # TODO: remove this pinned matplotlib version once
-    # https://github.com/matplotlib/matplotlib/issues/5836 is fixed
-
-    if [[ ! -z $pin_file ]]; then
-        if [[ -z $(grep matplotlib $pin_file) ]]; then
-            echo "matplotlib !=1.5.1" >> $pin_file
-        else
-            echo "Due to a matplotlib issue (#5836), the version for the
-            sphinx builds needs to be !=1.5.1. This may override the version
-            number specified in $MATPLOTLIB_VERSION"
-            awk  '{if ($1 == "matplotlib")
-                       if ($2 == "1.5.1*" || NF == 1)
-                           print "matplotlib !=1.5.1";
-                       else print "matplotlib "$2",!=1.5.1";
-                   else print $0}' $pin_file > /tmp/pin_file_temp
-            mv /tmp/pin_file_temp $pin_file
-        fi
-    else
-        echo "matplotlib !=1.5.1" >> $pin_file
-    fi
-
     if [[ $DEBUG == True ]]; then
         cat $pin_file
     fi


### PR DESCRIPTION
**Do not merge until there is a new helpers release, as without https://github.com/astropy/astropy-helpers/pull/223 still brakes the py3 builds.**

It seems that there are (two ways)[https://github.com/matplotlib/matplotlib/issues/5836#issuecomment-212052820] to fix the issue we had with the mpl font caching (e.g. #56). 

The first solution is to import mpl before running the tests (sphinx build), the second is to enable caching. 
I think the first one can be sensibly done here in ci-helpers, while the second requires each package to edit their ``.travis.yml``.  