### PR TITLE
Fixing mkl version to 11.3.1 for appveyor conda installs

### DIFF
--- a/appveyor/install-miniconda.ps1
+++ b/appveyor/install-miniconda.ps1
@@ -134,11 +134,14 @@ if ($env:CONDA_DEPENDENCIES) {
     $CONDA_DEPENDENCIES = ""
 }
 
-# Due to scipy DLL issues with mkl 11.3.3, we should not depend on mkl for now
-# as a workaround see discussion in
-# https://github.com/astropy/astropy/pull/4907#issuecomment-219200964
+# Due to scipy DLL issues with mkl 11.3.3, and as there is no nomkl option
+# for windows, we should use mkl 11.3.1 for now as a workaround see discussion
+# in https://github.com/astropy/astropy/pull/4907#issuecomment-219200964
 
-conda install -n test -q nomkl
+if ($NUMPY_OPTION -ne "") {
+   $NUMPY_OPTION_mkl = "mkl=11.3.1 " + $NUMPY_OPTION
+   $NUMPY_OPTION = $NUMPY_OPTION_mkl
+}
 
 conda install -n test -q pytest $NUMPY_OPTION $ASTROPY_OPTION $CONDA_DEPENDENCIES
 

--- a/appveyor/install-miniconda.ps1
+++ b/appveyor/install-miniconda.ps1
@@ -134,6 +134,12 @@ if ($env:CONDA_DEPENDENCIES) {
     $CONDA_DEPENDENCIES = ""
 }
 
+# Due to scipy DLL issues with mkl 11.3.3, we should not depend on mkl for now
+# as a workaround see discussion in
+# https://github.com/astropy/astropy/pull/4907#issuecomment-219200964
+
+conda install -n test -q nomkl
+
 conda install -n test -q pytest $NUMPY_OPTION $ASTROPY_OPTION $CONDA_DEPENDENCIES
 
 # Check whether the developer version of Numpy is required and if yes install it

--- a/appveyor/install-miniconda.ps1
+++ b/appveyor/install-miniconda.ps1
@@ -140,7 +140,8 @@ if ($env:CONDA_DEPENDENCIES) {
 
 if ($NUMPY_OPTION -ne "") {
    $NUMPY_OPTION_mkl = "mkl=11.3.1 " + $NUMPY_OPTION
-   $NUMPY_OPTION = $NUMPY_OPTION_mkl
+   echo $NUMPY_OPTION_mkl
+   $NUMPY_OPTION = $NUMPY_OPTION_mkl.Split(" ")
 }
 
 conda install -n test -q pytest $NUMPY_OPTION $ASTROPY_OPTION $CONDA_DEPENDENCIES


### PR DESCRIPTION
 as mkl 11.3.3 has some issues with scipy (11.3.1 worked fine)

See https://github.com/astropy/astropy/pull/4907 for the start of the discussion.

[Edit]:  - There is no ``nomkl``, thus I went with hardwiring the mkl version to 11.3.1 that worked before. Everyone else is seeing this issue with scipy, and I believe this is the official conda issue for it is https://github.com/ContinuumIO/anaconda-issues/issues/792. I'll remove the version limit once it's solved upstream. 