### PR TITLE
Use built-in Miniconda on AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@
 environment:
 
   global:
-      PYTHON: "C:\\conda"
+      PYTHON: "C:\\Miniconda"
       MINICONDA_VERSION: "latest"
       CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\ci-helpers\\appveyor\\windows_sdk.cmd"
       PYTHON_ARCH: "64" # needs to be set for CMD_IN_ENV to succeed. If a mix

--- a/appveyor/install-miniconda.ps1
+++ b/appveyor/install-miniconda.ps1
@@ -3,73 +3,10 @@
 # Borrwed from: Olivier Grisel and Kyle Kastner
 # License: BSD 3 clause
 
-$MINICONDA_URL = "http://repo.continuum.io/miniconda/"
-
 if (! $env:ASTROPY_LTS_VERSION) {
    $env:ASTROPY_LTS_VERSION = "1.0"
 }
 
-function DownloadMiniconda ($version, $platform_suffix) {
-    $webclient = New-Object System.Net.WebClient
-    $filename = "Miniconda-" + $version + "-Windows-" + $platform_suffix + ".exe"
-
-    $url = $MINICONDA_URL + $filename
-
-    $basedir = $pwd.Path + "\"
-    $filepath = $basedir + $filename
-    if (Test-Path $filename) {
-        Write-Host "Reusing" $filepath
-        return $filepath
-    }
-
-    # Download and retry up to 3 times in case of network transient errors.
-    Write-Host "Downloading" $filename "from" $url
-    $retry_attempts = 2
-    for($i=0; $i -lt $retry_attempts; $i++){
-        try {
-            $webclient.DownloadFile($url, $filepath)
-            break
-        }
-        Catch [Exception]{
-            Start-Sleep 1
-        }
-   }
-   if (Test-Path $filepath) {
-       Write-Host "File saved at" $filepath
-   } else {
-       # Retry once to get the error message if any at the last try
-       $webclient.DownloadFile($url, $filepath)
-   }
-   return $filepath
-}
-
-function InstallMiniconda ($miniconda_version, $architecture, $python_home) {
-    Write-Host "Installing miniconda" $miniconda_version "for" $architecture "bit architecture to" $python_home
-    if (Test-Path $python_home) {
-        Write-Host $python_home "already exists, skipping."
-        return $false
-    }
-    if ($architecture -eq "x86") {
-        $platform_suffix = "x86"
-    } else {
-        $platform_suffix = "x86_64"
-    }
-    $filepath = DownloadMiniconda $miniconda_version $platform_suffix
-    Write-Host "Installing" $filepath "to" $python_home
-    $args = "/InstallationType=AllUsers /S /AddToPath=1 /RegisterPython=1 /D=" + $python_home
-    Write-Host $filepath $args
-    Start-Process -FilePath $filepath -ArgumentList $args -Wait -Passthru
-    #Start-Sleep -s 15
-    if (Test-Path $python_home) {
-        Write-Host "Miniconda $miniconda_version ($architecture) installation complete"
-    } else {
-        Write-Host "Failed to install Python in $python_home"
-        Exit 1
-    }
-}
-
-# Install miniconda
-InstallMiniconda $env:MINICONDA_VERSION $env:PLATFORM $env:PYTHON
 
 # Set environment variables
 $env:PATH = "${env:PYTHON};${env:PYTHON}\Scripts;" + $env:PATH


### PR DESCRIPTION
I often see this error on AppVeyor:

https://ci.appveyor.com/project/astrofrog/glue-3d-viewer/build/1.0.265

Not sure what causes this flakiness, but it turns out Miniconda is already installed on AppVeyor, so this PR is just an experiment to see if we can just use that.