### PR TITLE
Using latest miniconda for appveyor when no version is given 

### DIFF
--- a/appveyor/install-miniconda.ps1
+++ b/appveyor/install-miniconda.ps1
@@ -68,7 +68,11 @@ function InstallMiniconda ($miniconda_version, $architecture, $python_home) {
     }
 }
 
-# Install miniconda
+# Install miniconda, if no version is given use the latest
+if (! $env:MINICONDA_VERSION) {
+   $env:MINICONDA_VERSION="latest"
+}
+
 InstallMiniconda $env:MINICONDA_VERSION $env:PLATFORM $env:PYTHON
 
 # Set environment variables


### PR DESCRIPTION
This closes #85

@astrofrog - Not sure that we can test it, what do you think?
(I'll remove the [skip ci] during rebase, once your PR is in)