### PR TITLE
Add option to force installing dependencies during egg_info builds

### DIFF
--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -50,7 +50,7 @@ conda create $QUIET -n test python=$PYTHON_VERSION
 source activate test
 
 # EGG_INFO
-if [[ $SETUP_CMD == egg_info ]]; then
+if [ $SETUP_CMD == 'egg_info' ] && [ -z $FORCE_DEPENDENCIES_INSTALL ]; then
     return  # no more dependencies needed
 fi
 


### PR DESCRIPTION
This PR adds a check for an environment variable, `$FORCE_DEPENDENCIES_INSTALL`, that will force `setup_dependencies_common.sh` to build dependencies during `egg_info` builds. This is a solution to a problem that there may be other ways to solve, but has eluded me for a few months: 

I have two projects that I'm actively developing right now ("gala" and "biff"). Both contain C and Cython code along with Python code, and Biff depends on both the Cython and C code in Gala. Because of that, in order to build an egg of Biff, I need to build Gala. Locally, this is fine, but on travis my builds fail because of [this line](https://github.com/astropy/ci-helpers/blob/master/travis/setup_dependencies_common.sh#L53). With the env variable added in this PR, I can tell the setup script to build the dependencies even during an egg_info build. 

I haven't figured out how to add a test for this new functionality...