### PR TITLE
Adding support for pycodestyle as the renaming of pep8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -97,6 +97,10 @@ matrix:
           env: MAIN_CMD='pep8'
                TEST_CMD='pep8 --version'
 
+        - os: linux
+          env: MAIN_CMD='pycodestyle'
+               TEST_CMD='pycodestyle --version'
+
         - os: osx
           env: SETUP_CMD='test' ASTROPY_VERSION=LTS
                CONDA_DEPENDENCIES='requests'

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Following this, various dependencies are installed depending on the following en
 * ``MAIN_CMD``: if this starts with ``pycodestyle``, then the only package
   that gets installed is the ``pycodestyle`` package. Please note that the
   former name of the ``pycodestyle`` package is ``pep8``, and ci-helpers
-  still excepts it, too.
+  still accepts it, too.
 
 * ``SETUP_CMD``: this can be set to various values:
 

--- a/README.md
+++ b/README.md
@@ -39,8 +39,10 @@ This does the following:
 
 Following this, various dependencies are installed depending on the following environment variables
 
-* ``MAIN_CMD``: if this starts with ``pep8``, then the only package that gets
-  installed is the ``pep8`` package.
+* ``MAIN_CMD``: if this starts with ``pycodestyle``, then the only package
+  that gets installed is the ``pycodestyle`` package. Please note that the
+  former name of the ``pycodestyle`` package is ``pep8``, and ci-helpers
+  still excepts it, too.
 
 * ``SETUP_CMD``: this can be set to various values:
 
@@ -120,9 +122,10 @@ script:
 
 The typical usage will then be to set ``$MAIN_CMD`` to default to ``python
 setup.py`` and then set ``$SETUP_CMD='test'``, and this then allows special
-builds that have ``$MAIN_CMD='pep8'`` and ``$SETUP_CMD=''``.
+builds that have ``$MAIN_CMD='pycodestyle'`` and ``$SETUP_CMD=''``.
 
-Packages can also choose to not use the ``$MAIN_CMD`` variable and instead to set the ``script`` section to:
+Packages can also choose to not use the ``$MAIN_CMD`` variable and instead
+to set the ``script`` section to:
 
 ```
 script:

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -60,8 +60,14 @@ conda install $QUIET pytest pip
 export PIP_INSTALL='pip install'
 
 # PEP8
+# PEP8 has been renamed to pycodestyle, keep both here for now
 if [[ $MAIN_CMD == pep8* ]]; then
     $PIP_INSTALL pep8
+    return  # no more dependencies needed
+fi
+
+if [[ $MAIN_CMD == pycodestyle* ]]; then
+    $PIP_INSTALL pycodestyle
     return  # no more dependencies needed
 fi
 


### PR DESCRIPTION
This is to close #94.

@astrofrog - I think we should have the pep8 option around until it is pip installable, however I think it should be removed from the readme.