### PR TITLE
Remove astropy-ci-extras from the default conda channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ This does the following:
 - Set up the PATH appropriately.
 - Set up a conda environment named 'test' and switch to it.
 - Set the ``always_yes`` config option for conda to ``true`` so that you don't need to include ``--yes``.
-- Register the specified channels, or if not stated the ``astropy``, ``astropy-ci-extras``, and ``openastronomy`` channels.
+- Register the specified channels, or if not stated the ``astropy``, and ``openastronomy`` channels.
 - ``export PYTHONIOENCODING=UTF8``
 
 Following this, various dependencies are installed depending on the following environment variables
@@ -94,7 +94,7 @@ Following this, various dependencies are installed depending on the following en
   installing ``PIP_DEPENDENCIES``
 
 * ``$CONDA_CHANNELS``: this should be a space-separated string of conda
-  channel names, and defaults to ``astropy``, ``astropy-ci-extras``, and
+  channel names, and defaults to ``astropy``, and
   ``openastronomy``.
 
 * ``$DEBUG``: if `True` this turns on the shell debug mode in the install
@@ -160,7 +160,7 @@ This does the following:
 - Set up the PATH appropriately.
 - Set up a conda environment named 'test' and switch to it.
 - Set the ``always_yes`` config option for conda to ``true`` so that you don't need to include ``--yes``.
-- Register the specified channels, or if not stated the ``astropy``, ``astropy-ci-extras``, and ``openastronomy`` channels.
+- Register the specified channels, or if not stated the ``astropy``, and ``openastronomy`` channels.
 
 Following this, various dependencies are installed depending on the following environment variables
 
@@ -181,8 +181,7 @@ Following this, various dependencies are installed depending on the following en
   names that will be installed with conda.
 
 * ``$CONDA_CHANNELS``: this should be a space-separated string of conda
-  channel names, and defaults to ``astropy``, ``astropy-ci-extras``, and
-  ``openastronomy``.
+  channel names, and defaults to ``astropy``, and ``openastronomy``.
 
 Details
 -------

--- a/appveyor/install-miniconda.ps1
+++ b/appveyor/install-miniconda.ps1
@@ -1,6 +1,6 @@
 ﻿# Sample script to install anaconda under windows
 # Authors: Stuart Mumford
-# Borrwed from: Olivier Grisel and Kyle Kastner
+# Borrowed from: Olivier Grisel and Kyle Kastner
 # License: BSD 3 clause
 
 $MINICONDA_URL = "https://repo.continuum.io/miniconda/"

--- a/appveyor/install-miniconda.ps1
+++ b/appveyor/install-miniconda.ps1
@@ -82,7 +82,7 @@ $env:PATH = "${env:PYTHON};${env:PYTHON}\Scripts;" + $env:PATH
 conda config --set always_yes true
 
 if (! $env:CONDA_CHANNELS) {
-   $CONDA_CHANNELS=@("astropy", "astropy-ci-extras", "openastronomy")
+   $CONDA_CHANNELS=@("astropy", "openastronomy")
 } else {
    $CONDA_CHANNELS=$env:CONDA_CHANNELS.split(" ")
 }

--- a/appveyor/install-miniconda.ps1
+++ b/appveyor/install-miniconda.ps1
@@ -80,6 +80,7 @@ $env:PATH = "${env:PYTHON};${env:PYTHON}\Scripts;" + $env:PATH
 
 # Conda config
 conda config --set always_yes true
+conda config --add channels defaults
 
 if (! $env:CONDA_CHANNELS) {
    $CONDA_CHANNELS=@("astropy", "openastronomy")

--- a/test_env.py
+++ b/test_env.py
@@ -73,7 +73,9 @@ def test_astropy():
         if 'dev' in os_astropy_version:
             assert 'dev' in astropy.__version__
         else:
-            if 'stable' in os_astropy_version:
+            if 'pre' in os_astropy_version:
+                assert re.match("[0-9.]*[0-9](rc[0-9])", astropy.__version__)
+            elif 'stable' in os_astropy_version:
                 assert astropy.__version__.startswith(LATEST_ASTROPY_STABLE)
             elif 'lts' in os_astropy_version:
                 assert astropy.__version__.startswith(LATEST_ASTROPY_LTS)

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -19,7 +19,7 @@ if [[ -z $ASTROPY_LTS_VERSION ]]; then
 fi
 
 if [[ -z $CONDA_CHANNELS ]]; then
-    CONDA_CHANNELS='astropy-ci-extras astropy openastronomy'
+    CONDA_CHANNELS='astropy openastronomy'
 fi
 
 if [[ -z $CONDA_DEPENDENCIES_FLAGS ]]; then

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -5,6 +5,7 @@ hash -r
 set -e
 
 conda config --set always_yes yes --set changeps1 no
+conda config --add channels defaults
 
 shopt -s nocasematch
 


### PR DESCRIPTION
This is a workaround for currently failing tests in astropy (e.g. https://github.com/astropy/astropy/pull/5094), a place for discussion for long term solution is in #98