### PR TITLE
Adding back astropy-ci-extras

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ This does the following:
 - Set up the PATH appropriately.
 - Set up a conda environment named 'test' and switch to it.
 - Set the ``always_yes`` config option for conda to ``true`` so that you don't need to include ``--yes``.
-- Register the specified channels, or if not stated the ``astropy``, and ``openastronomy`` channels.
+- Register the specified channels, or if not stated the ``astropy``, ``astropy-ci-extras``, and ``openastronomy`` channels.
 - ``export PYTHONIOENCODING=UTF8``
 
 Following this, various dependencies are installed depending on the following environment variables
@@ -94,7 +94,7 @@ Following this, various dependencies are installed depending on the following en
   installing ``PIP_DEPENDENCIES``
 
 * ``$CONDA_CHANNELS``: this should be a space-separated string of conda
-  channel names, and defaults to ``astropy``, and
+  channel names, and defaults to ``astropy``, ``astropy-ci-extras``, and
   ``openastronomy``.
 
 * ``$DEBUG``: if `True` this turns on the shell debug mode in the install
@@ -160,7 +160,7 @@ This does the following:
 - Set up the PATH appropriately.
 - Set up a conda environment named 'test' and switch to it.
 - Set the ``always_yes`` config option for conda to ``true`` so that you don't need to include ``--yes``.
-- Register the specified channels, or if not stated the ``astropy``, and ``openastronomy`` channels.
+- Register the specified channels, or if not stated the ``astropy``, ``astropy-ci-extras``, and ``openastronomy`` channels.
 
 Following this, various dependencies are installed depending on the following environment variables
 
@@ -181,7 +181,8 @@ Following this, various dependencies are installed depending on the following en
   names that will be installed with conda.
 
 * ``$CONDA_CHANNELS``: this should be a space-separated string of conda
-  channel names, and defaults to ``astropy``, and ``openastronomy``.
+  channel names, and defaults to ``astropy``, ``astropy-ci-extras``, and
+  ``openastronomy``.
 
 Details
 -------

--- a/appveyor/install-miniconda.ps1
+++ b/appveyor/install-miniconda.ps1
@@ -83,7 +83,7 @@ conda config --set always_yes true
 conda config --add channels defaults
 
 if (! $env:CONDA_CHANNELS) {
-   $CONDA_CHANNELS=@("astropy", "openastronomy")
+   $CONDA_CHANNELS=@("astropy", "openastronomy", "astropy-ci-extras")
 } else {
    $CONDA_CHANNELS=$env:CONDA_CHANNELS.split(" ")
 }

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -20,7 +20,7 @@ if [[ -z $ASTROPY_LTS_VERSION ]]; then
 fi
 
 if [[ -z $CONDA_CHANNELS ]]; then
-    CONDA_CHANNELS='astropy openastronomy'
+    CONDA_CHANNELS='astropy openastronomy astropy-ci-extras'
 fi
 
 if [[ -z $CONDA_DEPENDENCIES_FLAGS ]]; then


### PR DESCRIPTION
 as older numpy builds are failing without the astropy builds hosted in it. See discussion in #97 and #98 and on gitter.

We need to come up with a more roboust solution in the long term.