### PR TITLE
Making "stable" version be the latest feature release

### DIFF
--- a/appveyor/install-miniconda.ps1
+++ b/appveyor/install-miniconda.ps1
@@ -156,7 +156,7 @@ if ($env:PYTHON_VERSION -match "3.5") {
    conda install -n test -q vs2015_runtime=14.00.23026.0=0
 }
 
-conda install -n test -q pytest $NUMPY_OPTION $ASTROPY_OPTION $CONDA_DEPENDENCIES
+conda install -n test -q pytest --no-channel-priority $NUMPY_OPTION $ASTROPY_OPTION $CONDA_DEPENDENCIES
 
 # Check whether the developer version of Numpy is required and if yes install it
 if ($env:NUMPY_VERSION -match "dev") {

--- a/appveyor/install-miniconda.ps1
+++ b/appveyor/install-miniconda.ps1
@@ -94,6 +94,10 @@ foreach ($CONDA_CHANNEL in $CONDA_CHANNELS) {
 # Install the build and runtime dependencies of the project.
 conda update -q conda
 
+# We need to add this after the update, otherwise the ``channel_priority``
+# key may not yet exists
+conda config  --set channel_priority false
+
 # Create a conda environment using the astropy bonus packages
 conda create -q -n test python=$env:PYTHON_VERSION
 activate test
@@ -156,7 +160,7 @@ if ($env:PYTHON_VERSION -match "3.5") {
    conda install -n test -q vs2015_runtime=14.00.23026.0=0
 }
 
-conda install -n test -q pytest --no-channel-priority $NUMPY_OPTION $ASTROPY_OPTION $CONDA_DEPENDENCIES
+conda install -n test -q pytest $NUMPY_OPTION $ASTROPY_OPTION $CONDA_DEPENDENCIES
 
 # Check whether the developer version of Numpy is required and if yes install it
 if ($env:NUMPY_VERSION -match "dev") {

--- a/test_env.py
+++ b/test_env.py
@@ -19,7 +19,8 @@ if 'TRAVIS_REPO_SLUG' in os.environ:
 # The test scripts accept 'stable' for ASTROPY_VERSION to test that it's
 # properly parsed hard-wire the latest stable branch version here
 
-LATEST_ASTROPY_STABLE = '1.1'
+LATEST_ASTROPY_STABLE = '1.2'
+LATEST_ASTROPY_STABLE_WIN = '1.1.2'
 LATEST_ASTROPY_LTS = '1.0'
 LATEST_NUMPY_STABLE = '1.11'
 
@@ -76,7 +77,10 @@ def test_astropy():
             if 'pre' in os_astropy_version:
                 assert re.match("[0-9.]*[0-9](rc[0-9])", astropy.__version__)
             elif 'stable' in os_astropy_version:
-                assert astropy.__version__.startswith(LATEST_ASTROPY_STABLE)
+                if 'APPVEYOR' in os.environ:
+                    assert astropy.__version__.startswith(LATEST_ASTROPY_STABLE_WIN)
+                else:
+                    assert astropy.__version__.startswith(LATEST_ASTROPY_STABLE)
             elif 'lts' in os_astropy_version:
                 assert astropy.__version__.startswith(LATEST_ASTROPY_LTS)
             else:

--- a/test_env.py
+++ b/test_env.py
@@ -20,7 +20,7 @@ if 'TRAVIS_REPO_SLUG' in os.environ:
 # properly parsed hard-wire the latest stable branch version here
 
 LATEST_ASTROPY_STABLE = '1.2'
-LATEST_ASTROPY_STABLE_WIN = '1.1.2'
+LATEST_ASTROPY_STABLE_WIN = '1.2'
 LATEST_ASTROPY_LTS = '1.0'
 LATEST_NUMPY_STABLE = '1.11'
 

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -128,8 +128,8 @@ if [[ $NUMPY_VERSION == dev* ]]; then
     # We then install Numpy itself at the bottom of this script
     export CONDA_INSTALL="conda install $QUIET python=$PYTHON_VERSION"
 elif [[ $NUMPY_VERSION == stable ]]; then
-    conda install $QUIET numpy
-    export CONDA_INSTALL="conda install $QUIET python=$PYTHON_VERSION"
+    conda install $QUIET numpy=$LATEST_NUMPY_STABLE
+    export CONDA_INSTALL="conda install $QUIET python=$PYTHON_VERSION numpy=$LATEST_NUMPY_VERSION"
 elif [[ $NUMPY_VERSION == pre* ]]; then
     conda install $QUIET numpy
     export CONDA_INSTALL="conda install $QUIET python=$PYTHON_VERSION"
@@ -254,17 +254,6 @@ fi
 if [[ $NUMPY_VERSION == pre* ]]; then
     $PIP_INSTALL --pre --upgrade numpy
 fi
-
-# NUMPY STABLE
-
-# Due to recent instability in conda, sometimes very old versions are picked
-# up for the "stable" numpy alias. We should revise and possibly remove this
-# once (https://github.com/conda/conda/issues/2777) is solved.
-
-if [[ $NUMPY_VERSION == stable ]]; then
-    $PIP_INSTALL --upgrade --no-deps numpy==$LATEST_NUMPY_STABLE
-fi
-
 
 # ASTROPY DEV and PRE
 

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -7,6 +7,8 @@ set -e
 conda config --set always_yes yes --set changeps1 no
 conda config --add channels defaults
 
+conda --no-channel-priority
+
 shopt -s nocasematch
 
 LATEST_ASTROPY_STABLE=1.1

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -7,8 +7,6 @@ set -e
 conda config --set always_yes yes --set changeps1 no
 conda config --add channels defaults
 
-conda --no-channel-priority
-
 shopt -s nocasematch
 
 LATEST_ASTROPY_STABLE=1.1
@@ -61,7 +59,7 @@ if [[ $SETUP_CMD == egg_info ]]; then
 fi
 
 # CORE DEPENDENCIES
-conda install $QUIET pytest pip
+conda install --no-channel-priority $QUIET pytest pip
 
 export PIP_INSTALL='pip install'
 
@@ -128,13 +126,13 @@ if [[ $NUMPY_VERSION == dev* ]]; then
     # if Scipy *is* still compiled against the MKL.
     conda install $QUIET nomkl
     # We then install Numpy itself at the bottom of this script
-    export CONDA_INSTALL="conda install $QUIET python=$PYTHON_VERSION"
+    export CONDA_INSTALL="conda install --no-channel-priority $QUIET python=$PYTHON_VERSION"
 elif [[ $NUMPY_VERSION == stable ]]; then
     conda install $QUIET numpy=$LATEST_NUMPY_STABLE
-    export CONDA_INSTALL="conda install $QUIET python=$PYTHON_VERSION numpy=$LATEST_NUMPY_VERSION"
+    export CONDA_INSTALL="conda install --no-channel-priority $QUIET python=$PYTHON_VERSION numpy=$LATEST_NUMPY_VERSION"
 elif [[ $NUMPY_VERSION == pre* ]]; then
     conda install $QUIET numpy
-    export CONDA_INSTALL="conda install $QUIET python=$PYTHON_VERSION"
+    export CONDA_INSTALL="conda install --no-channel-priority $QUIET python=$PYTHON_VERSION"
     if [[ -z $(pip list -o --pre | grep numpy | \
             grep -E "[0-9]rc[0-9]|[0-9][ab][0-9]") ]]; then
         # We want to stop the script if there isn't a pre-release available,
@@ -143,10 +141,10 @@ elif [[ $NUMPY_VERSION == pre* ]]; then
         exit
     fi
 elif [[ ! -z $NUMPY_VERSION ]]; then
-    conda install $QUIET numpy=$NUMPY_VERSION
-    export CONDA_INSTALL="conda install $QUIET python=$PYTHON_VERSION numpy=$NUMPY_VERSION"
+    conda install --no-channel-priority $QUIET numpy=$NUMPY_VERSION
+    export CONDA_INSTALL="conda install --no-channel-priority $QUIET python=$PYTHON_VERSION numpy=$NUMPY_VERSION"
 else
-    export CONDA_INSTALL="conda install $QUIET python=$PYTHON_VERSION"
+    export CONDA_INSTALL="conda install --no-channel-priority $QUIET python=$PYTHON_VERSION"
 fi
 
 # ASTROPY
@@ -154,7 +152,7 @@ if [[ ! -z $ASTROPY_VERSION ]]; then
     if [[ $ASTROPY_VERSION == dev* ]]; then
         : # Install at the bottom of this script
     elif [[ $ASTROPY_VERSION == pre* ]]; then
-        conda install astropy
+        conda install --no-channel-priority astropy
         if [[ -z $(pip list -o --pre | grep astropy | \
             grep -E "[0-9]rc[0-9]|[0-9][ab][0-9]") ]]; then
             # We want to stop the script if there isn't a pre-release available,
@@ -249,7 +247,7 @@ fi
 # would override Numpy dev or pre.
 
 if [[ $NUMPY_VERSION == dev* ]]; then
-    conda install $QUIET Cython
+    conda install --no-channel-priority $QUIET Cython
     $PIP_INSTALL git+https://github.com/numpy/numpy.git#egg=numpy --upgrade --no-deps
 fi
 
@@ -315,7 +313,7 @@ fi
 
 if [[ $DEBUG == True ]]; then
     # include debug information about the current conda install
-    conda install -n root _license
+    conda install --no-channel-priority -n root _license
     conda info -a
 fi
 

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -6,7 +6,6 @@ set -e
 
 conda config --set always_yes yes --set changeps1 no
 conda config --add channels defaults
-conda config  --set channel_priority false
 
 shopt -s nocasematch
 
@@ -41,6 +40,10 @@ do
 done
 
 conda update $QUIET conda
+
+# We need to add this after the update, otherwise the ``channel_priority``
+# key may not yet exists
+conda config  --set channel_priority false
 
 # Use utf8 encoding. Should be default, but this is insurance against
 # future changes

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -284,9 +284,8 @@ fi
 
 if [[ $ASTROPY_VERSION == stable ]]; then
     if $(python -c "from distutils.version import LooseVersion; import astropy;\
-                    import os;\
-                    print(LooseVersion(astropy.__version__)) <\
-                    LooseVersion(os.environ['LATEST_ASTROPY_STABLE'])"); then
+                    import os; print(LooseVersion(astropy.__version__) <\
+                    LooseVersion(os.environ['LATEST_ASTROPY_STABLE']))"); then
         $PIP_INSTALL --upgrade --no-deps astropy==$LATEST_ASTROPY_STABLE
     fi
 fi

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -6,6 +6,7 @@ set -e
 
 conda config --set always_yes yes --set changeps1 no
 conda config --add channels defaults
+conda config  --set channel_priority false
 
 shopt -s nocasematch
 
@@ -59,7 +60,7 @@ if [[ $SETUP_CMD == egg_info ]]; then
 fi
 
 # CORE DEPENDENCIES
-conda install --no-channel-priority $QUIET pytest pip
+conda install $QUIET pytest pip
 
 export PIP_INSTALL='pip install'
 
@@ -126,13 +127,13 @@ if [[ $NUMPY_VERSION == dev* ]]; then
     # if Scipy *is* still compiled against the MKL.
     conda install $QUIET nomkl
     # We then install Numpy itself at the bottom of this script
-    export CONDA_INSTALL="conda install --no-channel-priority $QUIET python=$PYTHON_VERSION"
+    export CONDA_INSTALL="conda install $QUIET python=$PYTHON_VERSION"
 elif [[ $NUMPY_VERSION == stable ]]; then
     conda install $QUIET numpy=$LATEST_NUMPY_STABLE
-    export CONDA_INSTALL="conda install --no-channel-priority $QUIET python=$PYTHON_VERSION numpy=$LATEST_NUMPY_STABLE"
+    export CONDA_INSTALL="conda install $QUIET python=$PYTHON_VERSION numpy=$LATEST_NUMPY_STABLE"
 elif [[ $NUMPY_VERSION == pre* ]]; then
     conda install $QUIET numpy
-    export CONDA_INSTALL="conda install --no-channel-priority $QUIET python=$PYTHON_VERSION"
+    export CONDA_INSTALL="conda install $QUIET python=$PYTHON_VERSION"
     if [[ -z $(pip list -o --pre | grep numpy | \
             grep -E "[0-9]rc[0-9]|[0-9][ab][0-9]") ]]; then
         # We want to stop the script if there isn't a pre-release available,
@@ -141,10 +142,10 @@ elif [[ $NUMPY_VERSION == pre* ]]; then
         exit
     fi
 elif [[ ! -z $NUMPY_VERSION ]]; then
-    conda install --no-channel-priority $QUIET numpy=$NUMPY_VERSION
-    export CONDA_INSTALL="conda install --no-channel-priority $QUIET python=$PYTHON_VERSION numpy=$NUMPY_VERSION"
+    conda install $QUIET numpy=$NUMPY_VERSION
+    export CONDA_INSTALL="conda install $QUIET python=$PYTHON_VERSION numpy=$NUMPY_VERSION"
 else
-    export CONDA_INSTALL="conda install --no-channel-priority $QUIET python=$PYTHON_VERSION"
+    export CONDA_INSTALL="conda install $QUIET python=$PYTHON_VERSION"
 fi
 
 # ASTROPY
@@ -152,7 +153,7 @@ if [[ ! -z $ASTROPY_VERSION ]]; then
     if [[ $ASTROPY_VERSION == dev* ]]; then
         : # Install at the bottom of this script
     elif [[ $ASTROPY_VERSION == pre* ]]; then
-        conda install --no-channel-priority astropy
+        conda install astropy
         if [[ -z $(pip list -o --pre | grep astropy | \
             grep -E "[0-9]rc[0-9]|[0-9][ab][0-9]") ]]; then
             # We want to stop the script if there isn't a pre-release available,
@@ -247,7 +248,7 @@ fi
 # would override Numpy dev or pre.
 
 if [[ $NUMPY_VERSION == dev* ]]; then
-    conda install --no-channel-priority $QUIET Cython
+    conda install $QUIET Cython
     $PIP_INSTALL git+https://github.com/numpy/numpy.git#egg=numpy --upgrade --no-deps
 fi
 
@@ -318,7 +319,7 @@ fi
 
 if [[ $DEBUG == True ]]; then
     # include debug information about the current conda install
-    conda install --no-channel-priority -n root _license
+    conda install -n root _license
     conda info -a
 fi
 

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -10,7 +10,6 @@ conda config --add channels defaults
 shopt -s nocasematch
 
 LATEST_ASTROPY_STABLE=1.1
-LATEST_ASTROPY_LTS=1.0
 LATEST_NUMPY_STABLE=1.11
 
 if [[ $DEBUG == True ]]; then
@@ -255,6 +254,17 @@ fi
 if [[ $NUMPY_VERSION == pre* ]]; then
     $PIP_INSTALL --pre --upgrade numpy
 fi
+
+# NUMPY STABLE
+
+# Due to recent instability in conda, sometimes very old versions are picked
+# up for the "stable" numpy alias. We should revise and possibly remove this
+# once (https://github.com/conda/conda/issues/2777) is solved.
+
+if [[ $NUMPY_VERSION == stable ]]; then
+    $PIP_INSTALL --upgrade --no-deps numpy==$LATEST_NUMPY_STABLE
+fi
+
 
 # ASTROPY DEV and PRE
 

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -9,7 +9,7 @@ conda config --add channels defaults
 
 shopt -s nocasematch
 
-LATEST_ASTROPY_STABLE=1.1
+export LATEST_ASTROPY_STABLE=1.1
 LATEST_NUMPY_STABLE=1.11
 
 if [[ $DEBUG == True ]]; then
@@ -279,7 +279,12 @@ fi
 # version of astropy.
 
 if [[ $ASTROPY_VERSION == stable ]]; then
-    $PIP_INSTALL --upgrade --no-deps astropy==$LATEST_ASTROPY_STABLE
+    if $(python -c "from distutils.version import LooseVersion; import astropy;\
+                    import os;\
+                    print(LooseVersion(astropy.__version__)) <\
+                    LooseVersion(os.environ('LATEST_ASTROPY_STABLE'))"); then
+        $PIP_INSTALL --upgrade --no-deps astropy==$LATEST_ASTROPY_STABLE
+    fi
 fi
 
 # PIP DEPENDENCIES

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -282,7 +282,7 @@ if [[ $ASTROPY_VERSION == stable ]]; then
     if $(python -c "from distutils.version import LooseVersion; import astropy;\
                     import os;\
                     print(LooseVersion(astropy.__version__)) <\
-                    LooseVersion(os.environ('LATEST_ASTROPY_STABLE'))"); then
+                    LooseVersion(os.environ['LATEST_ASTROPY_STABLE'])"); then
         $PIP_INSTALL --upgrade --no-deps astropy==$LATEST_ASTROPY_STABLE
     fi
 fi

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -9,7 +9,7 @@ conda config --add channels defaults
 
 shopt -s nocasematch
 
-export LATEST_ASTROPY_STABLE=1.1
+export LATEST_ASTROPY_STABLE=1.2
 LATEST_NUMPY_STABLE=1.11
 
 if [[ $DEBUG == True ]]; then
@@ -129,7 +129,7 @@ if [[ $NUMPY_VERSION == dev* ]]; then
     export CONDA_INSTALL="conda install --no-channel-priority $QUIET python=$PYTHON_VERSION"
 elif [[ $NUMPY_VERSION == stable ]]; then
     conda install $QUIET numpy=$LATEST_NUMPY_STABLE
-    export CONDA_INSTALL="conda install --no-channel-priority $QUIET python=$PYTHON_VERSION numpy=$LATEST_NUMPY_VERSION"
+    export CONDA_INSTALL="conda install --no-channel-priority $QUIET python=$PYTHON_VERSION numpy=$LATEST_NUMPY_STABLE"
 elif [[ $NUMPY_VERSION == pre* ]]; then
     conda install $QUIET numpy
     export CONDA_INSTALL="conda install --no-channel-priority $QUIET python=$PYTHON_VERSION"

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -9,6 +9,10 @@ conda config --add channels defaults
 
 shopt -s nocasematch
 
+LATEST_ASTROPY_STABLE=1.1
+LATEST_ASTROPY_LTS=1.0
+LATEST_NUMPY_STABLE=1.11
+
 if [[ $DEBUG == True ]]; then
     QUIET=''
 else
@@ -266,7 +270,17 @@ if [[ $ASTROPY_VERSION == dev* ]]; then
 fi
 
 if [[ $ASTROPY_VERSION == pre* ]]; then
-    $PIP_INSTALL --pre --upgrade astropy
+    $PIP_INSTALL --pre --upgrade --no-deps astropy
+fi
+
+# ASTROPY STABLE
+
+# Due to recent instability in conda, and as new releases are not built in
+# astropy-ci-extras, this workaround ensures that we use the latest stable
+# version of astropy.
+
+if [[ $ASTROPY_VERSION == stable ]]; then
+    $PIP_INSTALL --upgrade --no-deps astropy==$LATEST_ASTROPY_STABLE
 fi
 
 # PIP DEPENDENCIES


### PR DESCRIPTION
This is to work around the recent conda issues when a very old astropy version was picked up when asked for "stable". We make sure that the installed version is from the latest feature release.

In most cases we don't need to force it to be the latest bugfix release, and if a package needs that bugfix they should explicitly state that version number in their travis file rather than use stable.

This is for #100 #98 