### PR TITLE
Pinning conda version to 4.1.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -125,7 +125,7 @@ matrix:
         - os: linux
           env: SETUP_CMD='test --coverage' PYTHON_VERSION=2.7
                TEST_CMD='coverage run test_env.py'
-               CONDA_CHANNELS='astropy-ci-extras astrofrog'
+               CONDA_CHANNELS='astropy-ci-extras astrofrog conda-forge'
                CONDA_DEPENDENCIES='pyqt5' DEBUG=True
                NUMPY_VERSION=1.10 ASTROPY_VERSION=lts
 

--- a/appveyor/install-miniconda.ps1
+++ b/appveyor/install-miniconda.ps1
@@ -87,7 +87,7 @@ conda config --set always_yes true
 conda config --add channels defaults
 
 # Install the build and runtime dependencies of the project.
-conda update -q conda=$env:CONDA_VERSION
+conda install -q conda=$env:CONDA_VERSION
 
 if (! $env:CONDA_CHANNELS) {
    $CONDA_CHANNELS=@("astropy", "openastronomy", "astropy-ci-extras")

--- a/appveyor/install-miniconda.ps1
+++ b/appveyor/install-miniconda.ps1
@@ -9,6 +9,10 @@ if (! $env:ASTROPY_LTS_VERSION) {
    $env:ASTROPY_LTS_VERSION = "1.0"
 }
 
+if (! $env:CONDA_VERSION) {
+   $env:CONDA_VERSION = "4.1.3"
+}
+
 function DownloadMiniconda ($version, $platform_suffix) {
     $webclient = New-Object System.Net.WebClient
     $filename = "Miniconda-" + $version + "-Windows-" + $platform_suffix + ".exe"
@@ -82,6 +86,9 @@ $env:PATH = "${env:PYTHON};${env:PYTHON}\Scripts;" + $env:PATH
 conda config --set always_yes true
 conda config --add channels defaults
 
+# Install the build and runtime dependencies of the project.
+conda update -q conda=$env:CONDA_VERSION
+
 if (! $env:CONDA_CHANNELS) {
    $CONDA_CHANNELS=@("astropy", "openastronomy", "astropy-ci-extras")
 } else {
@@ -90,9 +97,6 @@ if (! $env:CONDA_CHANNELS) {
 foreach ($CONDA_CHANNEL in $CONDA_CHANNELS) {
    conda config --add channels $CONDA_CHANNEL
 }
-
-# Install the build and runtime dependencies of the project.
-conda update -q conda
 
 # We need to add this after the update, otherwise the ``channel_priority``
 # key may not yet exists

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -38,8 +38,9 @@ if [[ -z $CONDA_VERSION ]]; then
     CONDA_VERSION=4.1.3
 fi
 
-PIN_FILE=$HOME/miniconda/envs/test/conda-meta/pinned
-echo "conda ${CONDA_VERSION}" > $PIN_FILE
+PIN_FILE_CONDA=$HOME/miniconda/conda-meta/pinned
+
+echo "conda ${CONDA_VERSION}" > $PIN_FILE_CONDA
 
 conda update $QUIET conda
 
@@ -62,6 +63,9 @@ fi
 # CONDA
 conda create $QUIET -n test python=$PYTHON_VERSION
 source activate test
+
+# PIN FILE
+PIN_FILE=$HOME/miniconda/envs/test/conda-meta/pinned
 
 # EGG_INFO
 if [[ $SETUP_CMD == egg_info ]]; then

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -34,12 +34,11 @@ if [[ -z $PIP_DEPENDENCIES_FLAGS ]]; then
    PIP_DEPENDENCIES_FLAGS=''
 fi
 
-for channel in $CONDA_CHANNELS
-do
+conda update $QUIET conda
+
+for channel in $CONDA_CHANNELS; do
     conda config --add channels $channel
 done
-
-conda update $QUIET conda
 
 # We need to add this after the update, otherwise the ``channel_priority``
 # key may not yet exists

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -42,7 +42,7 @@ PIN_FILE_CONDA=$HOME/miniconda/conda-meta/pinned
 
 echo "conda ${CONDA_VERSION}" > $PIN_FILE_CONDA
 
-conda update $QUIET conda
+conda install $QUIET conda
 
 for channel in $CONDA_CHANNELS; do
     conda config --add channels $channel


### PR DESCRIPTION
Obscure bugs came up again in conda (see https://github.com/conda/conda/issues/2897), this time between v4.1.3 and v4.1.4 so we decided to pin the version and only upgrade when we have resources to test the behaviours of a new release.



