### PR TITLE
Fixing bug in stable version workaround

### DIFF
--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -262,9 +262,12 @@ fi
 # version of astropy.
 
 if [[ $ASTROPY_VERSION == stable ]]; then
-    if $(python -c "from distutils.version import LooseVersion; import astropy;\
-                    import os; print(LooseVersion(astropy.__version__) <\
-                    LooseVersion(os.environ['LATEST_ASTROPY_STABLE']))"); then
+    old_astropy=$(python -c "from distutils.version import LooseVersion;\
+                  import astropy; import os;\
+                  print(LooseVersion(astropy.__version__) <\
+                  LooseVersion(os.environ['LATEST_ASTROPY_STABLE']))")
+
+    if [[ $old_astropy == True ]]; then
         $PIP_INSTALL --upgrade --no-deps astropy==$LATEST_ASTROPY_STABLE
     fi
 fi


### PR DESCRIPTION
Someone (@cdeil if I remember correctly) pointed out this bug, but I can't find the original issue now. It slipped through as it worked with bash on osx, but apparently not for linux. I don't see an obvious way to test it though. 