### PR TITLE
Using previous VS in appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -48,6 +48,8 @@ environment:
 platform:
     -x64
 
+os: Previous Visual Studio 2015
+
 install:
 
     # Install Miniconda


### PR DESCRIPTION
as current one gives internal compiler error for astropy dev

related issues:
https://github.com/astropy/astropy/issues/5137
https://github.com/appveyor/ci/issues/890