### PR TITLE
Removing temporary version pinning of vs2015_runtime

### DIFF
--- a/appveyor/install-miniconda.ps1
+++ b/appveyor/install-miniconda.ps1
@@ -157,13 +157,6 @@ if ($NUMPY_OPTION -ne "") {
    $NUMPY_OPTION = $NUMPY_OPTION_mkl.Split(" ")
 }
 
-# We have to fix the version of the vs2015_runtime on Python 3.5 to avoid
-# issues. See https://github.com/astropy/ci-helpers/issues/92 for more details.
-
-if ($env:PYTHON_VERSION -match "3.5") {
-   conda install -n test -q vs2015_runtime=14.00.23026.0=0
-}
-
 conda install -n test -q pytest $NUMPY_OPTION $ASTROPY_OPTION $CONDA_DEPENDENCIES
 
 # Check whether the developer version of Numpy is required and if yes install it


### PR DESCRIPTION
 as the upstream issue seems to be solved.

cc @astrofrog: What do you say, can we remove this now?

(original PR was #93 to address #92) 