### PR TITLE
Changing order of conda channels, so astrpy is overtaking openastronomy

### DIFF
--- a/appveyor/install-miniconda.ps1
+++ b/appveyor/install-miniconda.ps1
@@ -90,7 +90,7 @@ conda config --add channels defaults
 conda install -q conda=$env:CONDA_VERSION
 
 if (! $env:CONDA_CHANNELS) {
-   $CONDA_CHANNELS=@("astropy", "openastronomy", "astropy-ci-extras")
+   $CONDA_CHANNELS=@("openastronomy", "astropy-ci-extras", "astropy")
 } else {
    $CONDA_CHANNELS=$env:CONDA_CHANNELS.split(" ")
 }

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -23,7 +23,7 @@ if [[ -z $ASTROPY_LTS_VERSION ]]; then
 fi
 
 if [[ -z $CONDA_CHANNELS ]]; then
-    CONDA_CHANNELS='astropy openastronomy astropy-ci-extras'
+    CONDA_CHANNELS='openastronomy astropy-ci-extras astropy'
 fi
 
 if [[ -z $CONDA_DEPENDENCIES_FLAGS ]]; then


### PR DESCRIPTION
The conda channel ``openastronomy`` has builds copied over from ``astropy``, so actually it's better to have to pick those packages from the original astropy channel...