### PR TITLE
Adding defaults channel last to have higher priority

### DIFF
--- a/appveyor/install-miniconda.ps1
+++ b/appveyor/install-miniconda.ps1
@@ -98,6 +98,10 @@ foreach ($CONDA_CHANNEL in $CONDA_CHANNELS) {
    conda config --add channels $CONDA_CHANNEL
 }
 
+# Make defaults channel the highest priority install packages from there
+# if available rather than from e.g. conda-forge
+conda config --add channels defaults
+
 # We need to add this after the update, otherwise the ``channel_priority``
 # key may not yet exists
 conda config  --set channel_priority false

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -48,6 +48,10 @@ for channel in $CONDA_CHANNELS; do
     conda config --add channels $channel
 done
 
+# Make defaults channel the highest priority install packages from there
+# if available rather than from e.g. conda-forge
+conda config --add channels defaults
+
 # We need to add this after the update, otherwise the ``channel_priority``
 # key may not yet exists
 conda config  --set channel_priority false


### PR DESCRIPTION
To avoid picking up packages from e.g conda-forge.

E.g.:
https://travis-ci.org/bsipocz/sunpy/jobs/148693645#L495 vs. exact same build with different channel order
https://travis-ci.org/bsipocz/sunpy/jobs/148693840#L487

