### PR TITLE
Adding --ignore-installed to the stable astropy version upgrade

### DIFF
--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -280,7 +280,7 @@ if [[ $ASTROPY_VERSION == stable ]]; then
                   LooseVersion(os.environ['LATEST_ASTROPY_STABLE']))")
 
     if [[ $old_astropy == True ]]; then
-        $PIP_INSTALL --upgrade --no-deps astropy==$LATEST_ASTROPY_STABLE
+        $PIP_INSTALL --upgrade --no-deps --ignore-installed astropy==$LATEST_ASTROPY_STABLE
     fi
 fi
 


### PR DESCRIPTION
Apparently the version upgrade is not working for this workaround. The error is this (from this [travis build](https://travis-ci.org/astropy/astroquery/jobs/150688336#L517):

```
The following packages will be downloaded:

    package                    |            build

    ---------------------------|-----------------

    astropy-1.0.1              |       np18py33_0         7.6 MB  astropy-ci-extras

The following NEW packages will be INSTALLED:

    astropy: 1.0.1-np18py33_0 astropy-ci-extras

Fetching package metadata ...........

Solving package specifications: ..........

# All requested packages already installed.

# packages in environment at /home/travis/miniconda/envs/test:

#

beautiful-soup            4.3.2                    py33_0  

html5lib                  0.999                    py33_0  

matplotlib                1.4.0                np18py33_0  

numpy                     1.8.2                    py33_1  

python                    3.3.5                         4  

requests                  2.9.1                    py33_0  

Collecting astropy==1.2

  Downloading astropy-1.2.tar.gz (8.2MB)

    100% |████████████████████████████████| 8.2MB 51kB/s 

Building wheels for collected packages: astropy

  Running setup.py bdist_wheel for astropy ... |-||\--/|\\-/\\--/||-\|-\|-\|/\|/-\/-|\-|-|-\|/-\|/-|/-\|/-\|-\|/-\|-\|/-\|/-\/-\|/-|/-|-/-\|/-\|-/\|/\|/-\/-\|\|done

  Stored in directory: /home/travis/.cache/pip/wheels/f0/b0/14/fc48fcfbe0398cf474330bce472c375c5f043c60b4181a4e94

Successfully built astropy

Installing collected packages: astropy

  Found existing installation: astropy 1.0.1

Cannot remove entries from nonexistent file /home/travis/miniconda/envs/test/lib/python3.3/site-packages/easy-install.pth
```

Digging around a bit, e.g. https://github.com/pypa/pip/issues/2751, it seems that adding ``--ignore-installed`` will solve the issue.