### PR TITLE
Unfixed coverage version to use latest one

### DIFF
--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -304,10 +304,8 @@ fi
 # install this now in case the user installs cpp-coveralls via PIP_DEPENDENCIES.
 
 if [[ $SETUP_CMD == *coverage* ]]; then
-    # TODO can use latest version of coverage (4.0) once astropy 1.1 is out
-    # with the fix of https://github.com/astropy/astropy/issues/4175.
     # We install requests with conda since it's required by coveralls.
-    $CONDA_INSTALL coverage==3.7.1 requests
+    $CONDA_INSTALL coverage requests
     $PIP_INSTALL coveralls
 fi
 


### PR DESCRIPTION
Unfixed `coverage` version to use latest one (currently 4.2 from `conda`).

This is to possibly fix the timing problem in astropy/astropy#4826.

c/c @mhvk @MSeifert04