### PR TITLE
Removing the workaround of setting default sphinx version

### DIFF
--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -206,14 +206,6 @@ if [[ $SETUP_CMD == build_sphinx* ]] || [[ $SETUP_CMD == build_docs* ]]; then
         fi
     fi
 
-    # This is a temporary workaround of 2 warnings that appeared in the new
-    # 1.4 sphinx version, and that should be dealt with in
-    # astropy-helpers. This was we allow to override this version
-    # restriction by setting this variable in .travis.yml
-    if [[ -z $SPHINX_VERSION ]]; then
-        SPHINX_VERSION='<1.4'
-    fi
-
     if [[ ! -z $SPHINX_VERSION ]]; then
         if [[ -z $(grep sphinx $PIN_FILE) ]]; then
             echo "sphinx ${SPHINX_VERSION}*" >> $PIN_FILE


### PR DESCRIPTION
 as 1.4 supposed to work with astropy-helpers 1.2 and above. The workaround was introduces in #78.

https://github.com/astropy/astropy/pull/5567