### PR TITLE
Updating conda version from 4.1.3 to 4.3.4

### DIFF
--- a/appveyor/install-miniconda.ps1
+++ b/appveyor/install-miniconda.ps1
@@ -10,7 +10,7 @@ if (! $env:ASTROPY_LTS_VERSION) {
 }
 
 if (! $env:CONDA_VERSION) {
-   $env:CONDA_VERSION = "4.1.3"
+   $env:CONDA_VERSION = "4.3.4"
 }
 
 function DownloadMiniconda ($version, $platform_suffix) {

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -41,7 +41,7 @@ if [[ -z $PIP_DEPENDENCIES_FLAGS ]]; then
 fi
 
 if [[ -z $CONDA_VERSION ]]; then
-    CONDA_VERSION=4.1.3
+    CONDA_VERSION=4.3.4
 fi
 
 PIN_FILE_CONDA=$HOME/miniconda/conda-meta/pinned


### PR DESCRIPTION
@astrofrog - I would rather do this separately than the python 3.6. If this works, we can merge this asap and rebase the other PR that still waits for the packages to be available.