### PR TITLE
 Show conda config in DEBUG mode

### DIFF
--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -84,7 +84,7 @@ source activate test
 # PIN FILE
 PIN_FILE=$HOME/miniconda/envs/test/conda-meta/pinned
 
-if [[ $DEBUG == True ]];, then
+if [[ $DEBUG == True ]]; then
     conda config --show
 fi
 

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -84,6 +84,10 @@ source activate test
 # PIN FILE
 PIN_FILE=$HOME/miniconda/envs/test/conda-meta/pinned
 
+if [[ $DEBUG == True ]];, then
+    conda config --show
+fi
+
 # EGG_INFO
 if [[ $SETUP_CMD == egg_info ]]; then
     return  # no more dependencies needed


### PR DESCRIPTION
NOTE: this needs conda >=v4.2 so not yet suitable for merging.


This PR adds ``conda config --show`` to be run before the install process starts when in DEBUG mode. This should help with the recent warnings, e.g. here: https://travis-ci.org/astropy/package-template/jobs/192393463#L467