### PR TITLE
Pinning conda to 4.1.12

### DIFF
--- a/appveyor/install-miniconda.ps1
+++ b/appveyor/install-miniconda.ps1
@@ -9,6 +9,8 @@ if (! $env:ASTROPY_LTS_VERSION) {
    $env:ASTROPY_LTS_VERSION = "1.0"
 }
 
+# We pin the version for conda as it's not the most stable package from
+# release to release. Add note here if version is pinned due to a bug upstream.
 if (! $env:CONDA_VERSION) {
    $env:CONDA_VERSION = "4.3.4"
 }

--- a/appveyor/install-miniconda.ps1
+++ b/appveyor/install-miniconda.ps1
@@ -11,8 +11,9 @@ if (! $env:ASTROPY_LTS_VERSION) {
 
 # We pin the version for conda as it's not the most stable package from
 # release to release. Add note here if version is pinned due to a bug upstream.
+# Pin to 4.1.12 (most recent 4.3.4): https://github.com/conda/conda/issues/4324
 if (! $env:CONDA_VERSION) {
-   $env:CONDA_VERSION = "4.3.4"
+   $env:CONDA_VERSION = "4.1.12"
 }
 
 function DownloadMiniconda ($version, $platform_suffix) {

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -40,6 +40,8 @@ if [[ -z $PIP_DEPENDENCIES_FLAGS ]]; then
    PIP_DEPENDENCIES_FLAGS=''
 fi
 
+# We pin the version for conda as it's not the most stable package from
+# release to release. Add note here if version is pinned due to a bug upstream.
 if [[ -z $CONDA_VERSION ]]; then
     CONDA_VERSION=4.3.4
 fi

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -42,8 +42,9 @@ fi
 
 # We pin the version for conda as it's not the most stable package from
 # release to release. Add note here if version is pinned due to a bug upstream.
+# Pin to 4.1.12 (most recent 4.3.4): https://github.com/conda/conda/issues/4324
 if [[ -z $CONDA_VERSION ]]; then
-    CONDA_VERSION=4.3.4
+    CONDA_VERSION=4.1.12
 fi
 
 PIN_FILE_CONDA=$HOME/miniconda/conda-meta/pinned


### PR DESCRIPTION
Current conda latest raises a KeyError (see https://github.com/conda/conda/issues/4324) in one of the typical builds in the affiliates matrix, thus we need to pin to the last non failing version which seems to be 4.1.12. (While 4.2.x may fixed this issue, it has other unrelated errors related to downloads at least up until 4.2.15).