### PR TITLE
Using nomkl for numpy prereleases

### DIFF
--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -172,7 +172,7 @@ elif [[ $NUMPY_VERSION == stable ]]; then
     conda install $QUIET --no-pin numpy=$LATEST_NUMPY_STABLE
     export CONDA_INSTALL="conda install $QUIET python=$PYTHON_VERSION numpy=$LATEST_NUMPY_STABLE"
 elif [[ $NUMPY_VERSION == pre* ]]; then
-    conda install $QUIET --no-pin numpy
+    conda install $QUIET --no-pin nomkl numpy
     export CONDA_INSTALL="conda install $QUIET python=$PYTHON_VERSION"
     if [[ -z $(pip list -o --pre | grep numpy | \
             grep -E "[0-9]rc[0-9]|[0-9][ab][0-9]") ]]; then


### PR DESCRIPTION
This fixes crashing tests (e.g. see photutils or pydl) and closes #152.

At the moment there is no prerelease version, so difficult to test, but the concept was tested in [0] for photutils . Without this fix the test run usually halted and in ``test_core.py``, see [1], but now it passes and runs everything.

[0] https://travis-ci.org/bsipocz/photutils/jobs/193025698
[1] https://travis-ci.org/astropy/photutils/jobs/190715568