### PR TITLE
Unpinning conda version to the latest release 4.3.6

### DIFF
--- a/appveyor/install-miniconda.ps1
+++ b/appveyor/install-miniconda.ps1
@@ -11,9 +11,8 @@ if (! $env:ASTROPY_LTS_VERSION) {
 
 # We pin the version for conda as it's not the most stable package from
 # release to release. Add note here if version is pinned due to a bug upstream.
-# Pin to 4.1.12 (most recent 4.3.4): https://github.com/conda/conda/issues/4324
 if (! $env:CONDA_VERSION) {
-   $env:CONDA_VERSION = "4.1.12"
+   $env:CONDA_VERSION = "4.3.6"
 }
 
 function DownloadMiniconda ($version, $platform_suffix) {

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -42,9 +42,8 @@ fi
 
 # We pin the version for conda as it's not the most stable package from
 # release to release. Add note here if version is pinned due to a bug upstream.
-# Pin to 4.1.12 (most recent 4.3.4): https://github.com/conda/conda/issues/4324
 if [[ -z $CONDA_VERSION ]]; then
-    CONDA_VERSION=4.1.12
+    CONDA_VERSION=4.3.6
 fi
 
 PIN_FILE_CONDA=$HOME/miniconda/conda-meta/pinned


### PR DESCRIPTION
The error we got with conda 4.3.4 in #153 got fixed for 4.3.6. A test run with package helpers passes with all green, so this should be probably OK to go in. (Another test with astropy core is still running, but I'll be able to see the results by the time the tests for this PR finish.)