### PR TITLE
Failing job is the installing unsuccessful

### DIFF
--- a/appveyor/install-miniconda.ps1
+++ b/appveyor/install-miniconda.ps1
@@ -149,6 +149,7 @@ if ($env:ASTROPY_VERSION) {
         $ASTROPY_OPTION = "astropy=" + $env:ASTROPY_VERSION
     }
     $output = cmd /c conda install -n test -q $NUMPY_OPTION $ASTROPY_OPTION 2>&1
+    echo $output
     if ($output | select-string UnsatisfiableError) {
        echo "Installing astropy with conda was unsuccessful, using pip instead"
        pip install $ASTROPY_OPTION
@@ -166,8 +167,9 @@ if ($env:CONDA_DEPENDENCIES) {
 
 # Check whether the installation is successful, if not abort the build
 $output = cmd /c conda install -n test -q $NUMPY_OPTION $CONDA_DEPENDENCIES 2>&1
+
+echo $output
 if ($output | select-string UnsatisfiableError, PackageNotFoundError) {
-   echo "Exiting"
    $host.SetShouldExit(1)
 }
 

--- a/appveyor/install-miniconda.ps1
+++ b/appveyor/install-miniconda.ps1
@@ -150,6 +150,7 @@ if ($env:ASTROPY_VERSION) {
     }
     $output = cmd /c conda install -n test -q $NUMPY_OPTION $ASTROPY_OPTION 2>&1
     if ($output | select-string UnsatisfiableError) {
+       echo "Installing astropy with conda was unsuccessful, using pip instead"
        pip install $ASTROPY_OPTION
     }
 } else {
@@ -166,7 +167,8 @@ if ($env:CONDA_DEPENDENCIES) {
 # Check whether the installation is successful, if not abort the build
 $output = cmd /c conda install -n test -q $NUMPY_OPTION $CONDA_DEPENDENCIES 2>&1
 if ($output | select-string UnsatisfiableError, PackageNotFoundError) {
-   $host.SetShouldExit()
+   echo "Exiting"
+   $host.SetShouldExit(1)
 }
 
 # Check whether the developer version of Numpy is required and if yes install it

--- a/appveyor/install-miniconda.ps1
+++ b/appveyor/install-miniconda.ps1
@@ -163,7 +163,11 @@ if ($env:CONDA_DEPENDENCIES) {
     $CONDA_DEPENDENCIES = ""
 }
 
-conda install -n test -q $NUMPY_OPTION $CONDA_DEPENDENCIES
+# Check whether the installation is successful, if not abort the build
+$output = cmd /c conda install -n test -q $NUMPY_OPTION $CONDA_DEPENDENCIES 2>&1
+if ($output | select-string UnsatisfiableError, PackageNotFoundError) {
+   $host.SetShouldExit()
+}
 
 # Check whether the developer version of Numpy is required and if yes install it
 if ($env:NUMPY_VERSION -match "dev") {


### PR DESCRIPTION
This is ultimately to fix #87.
If the solution in #168  is favorable, we may want to try that for appveyor ,too (when conda install doesn't work, fall back to pip). However the exiting still need to be fixed in either case.

(I need to set up appveyor on my fork, but don't have much time atm, so letting this loose on a PR instead).