### PR TITLE
Tests should run on forks, and other minor fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,15 +45,17 @@ matrix:
           env: SETUP_CMD='test' NUMPY_VERSION=dev
                CONDA_DEPENDENCIES='scipy'
 
-        # -> Have non Python package in dependency list when falling back on
-        #    pip installing the dependencies to test whether test the
-        #    install one-by-one.
+        # -> Have non Python package (openjpeg) in dependency list when
+        #    falling back on pip installing the dependencies (as photutils is
+        #    missing from listed channels) to test the install one-by-one.
+        # -> Have package dependency that matches partially another package
+        #    (pytest vs pytest-cov) when falling back to pip install
         - os: linux
           env: SETUP_CMD='test --coverage' PYTHON_VERSION=3.5
                TEST_CMD='coverage run test_env.py'
                CONDA_CHANNELS='astropy-ci-extras astrofrog conda-forge'
-               CONDA_DEPENDENCIES='pyqt5 openjpeg photutils' DEBUG=True
-               NUMPY_VERSION=1.10 ASTROPY_VERSION=lts
+               CONDA_DEPENDENCIES='pyqt5 openjpeg photutils pytest pytest-cov'
+               DEBUG=True NUMPY_VERSION=1.10 ASTROPY_VERSION=lts
 
         # -> The pre build only should run to the testing phase if a pre
         #    release is available for numpy on pypi, otherwise it should pass

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ matrix:
         #    (pytest vs pytest-cov) when falling back to pip install
         - os: linux
           env: SETUP_CMD='test --coverage' PYTHON_VERSION=3.5
-               TEST_CMD='coverage run test_env.py'
+               TEST_CMD='py.test test_env.py && coverage run test_env.py'
                CONDA_CHANNELS='astropy-ci-extras astrofrog conda-forge'
                CONDA_DEPENDENCIES='pyqt5 openjpeg photutils pytest pytest-cov'
                DEBUG=True NUMPY_VERSION=1.10 ASTROPY_VERSION=lts

--- a/.travis.yml
+++ b/.travis.yml
@@ -150,4 +150,6 @@ before_install:
 
 script:
    - eval $TEST_CMD
+
+after_success:
    - if [[ $SETUP_CMD == *coverage* ]]; then coveralls; fi

--- a/test_env.py
+++ b/test_env.py
@@ -19,7 +19,7 @@ if 'APPVEYOR_PROJECT_SLUG' in os.environ:
             pytestmark = pytest.mark.skip()
 
 if 'TRAVIS_REPO_SLUG' in os.environ:
-    if os.environ['TRAVIS_REPO_SLUG'] != 'astropy/ci-helpers':
+    if os.environ['TRAVIS_REPO_SLUG'].split('/')[1] != 'ci-helpers':
         if PYTEST_LT_3:
             pytest.skip()
         else:

--- a/test_env.py
+++ b/test_env.py
@@ -112,6 +112,8 @@ def test_dependency_imports():
             __import__('skimage')
         elif package == 'openjpeg':
             continue
+        elif package == 'pytest-cov':
+            __import__('pytest_cov')
         elif package == '':
             continue
         else:

--- a/test_env.py
+++ b/test_env.py
@@ -110,6 +110,8 @@ def test_dependency_imports():
             __import__('PyQt5')
         elif package == 'scikit-image':
             __import__('skimage')
+        elif package == 'openjpeg':
+            continue
         elif package == '':
             continue
         else:

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -223,7 +223,7 @@ if [[ ! -z $ASTROPY_VERSION ]]; then
             echo "Installing astropy with conda was unsuccessful, using pip instead"
             $PIP_INSTALL astropy==$ASTROPY_OPTION
             if [[ -f $PIN_FILE ]]; then
-                grep -v astropy $PIN_FILE > /tmp/pin_file_temp
+                grep -vx astropy $PIN_FILE > /tmp/pin_file_temp
                 mv /tmp/pin_file_temp $PIN_FILE
             fi)
     fi
@@ -263,8 +263,8 @@ if [[ ! -z $CONDA_DEPENDENCIES ]]; then
         cp $PIN_FILE /tmp/pin_copy
         for package in $(echo $CONDA_DEPENDENCIES); do
             # We need to avoid other dependencies picked up from the pin file
-            echo $CONDA_DEPENDENCIES | tr " " "\n" | grep -v $package > /tmp/dependency_subset
-            grep -vf /tmp/dependency_subset /tmp/pin_copy > $PIN_FILE
+            echo $CONDA_DEPENDENCIES | tr " " "\n" | grep -vx $package > /tmp/dependency_subset
+            grep -vxf /tmp/dependency_subset /tmp/pin_copy > $PIN_FILE
             if [[ $DEBUG == True ]]; then
                 cat $PIN_FILE
             fi
@@ -273,7 +273,7 @@ if [[ ! -z $CONDA_DEPENDENCIES ]]; then
                 # We need to remove the problematic package from the pin
                 # file, otherwise further conda install commands may fail,
                 # too.
-                grep -v $package /tmp/pin_copy > /tmp/pin_copy_temp
+                grep -vx $package /tmp/pin_copy > /tmp/pin_copy_temp
                 mv /tmp/pin_copy_temp /tmp/pin_copy
                 $PIP_INSTALL $package);
         done


### PR DESCRIPTION
This PR fixes a few minor issues.

1) tests should run on forks rather than being skipped (https://travis-ci.org/bsipocz/ci-helpers/jobs/210285831#L842)
2) coverage, or in fact any extra script should run only after success from the main test script, otherwise failures become successes (see #175)
3) openjpeg is not a python package, do not try to import it (dealt with in the 3rd commit that will be pushed after the PR is opened to test whether the fix for the 2nd point is working and the build indeed fail)
4) should also fix the issue with partial matching of package names and including/excluding them from the pin file (see https://github.com/astropy/ci-helpers/pull/174#issuecomment-286129493 and above).
