### PR TITLE
Limit sphinx version when sphinx-gallery is used

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,19 @@ env:
 
 matrix:
     include:
+        # -> 2 Temporary tests, should be removed once
+        #    https://github.com/sphinx-gallery/sphinx-gallery/issues/241 is
+        #    addressed and workaround is removed
+        - os: linux
+          env: SETUP_CMD='build_docs'
+               PIP_DEPENDENCIES='sphinx-gallery requests'
+               CONDA_CHANNELS='conda-forge' PYTHON_VERSION=3.5
+               TEST_CMD='python -c "import sphinx; assert int(sphinx.__version__[2])<6"'
+        - os: linux
+          env: SETUP_CMD='build_docs'
+               PIP_DEPENDENCIES='requests' CONDA_DEPENDENCIES='pytest'
+               CONDA_CHANNELS='conda-forge' PYTHON_VERSION=3.5
+               TEST_CMD='python -c "import sphinx; assert int(sphinx.__version__[2])>=6"'
 
         # -> Starting with the dev versions as they take the longest to run. We
         #    deliberately test with Numpy 1.9 to check that installing Astropy

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -264,6 +264,13 @@ if [[ $SETUP_CMD == build_sphinx* ]] || [[ $SETUP_CMD == build_docs* ]]; then
         fi
     fi
 
+    # Temporary version limitation until
+    # https://github.com/sphinx-gallery/sphinx-gallery/issues/241 is addressed
+    if [[ -z $SPHINX_VERSION ]] && [[ ! -z $(echo $PIP_DEPENDENCIES $CONDA_DEPENDENCIES | \
+            grep sphinx-gallery) ]]; then
+        SPHINX_VERSION='<1.6'
+    fi
+
     if [[ ! -z $SPHINX_VERSION ]]; then
         if [[ -z $(grep sphinx $PIN_FILE) ]]; then
             echo "sphinx ${SPHINX_VERSION}*" >> $PIN_FILE


### PR DESCRIPTION
This is a workaround until https://github.com/sphinx-gallery/sphinx-gallery/issues/241 is addressed. 

The issue was first seen in https://github.com/sunpy/sunpy/pull/2103, but will bite astropy too once the sphinx version is update on the defaults channel (sunpy uses conda-forge, thus they run into it sooner).