### PR TITLE
Always limit sphinx version until astropy-helpers 2.0 is out

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,19 +27,13 @@ env:
 
 matrix:
     include:
-        # -> 2 Temporary tests, should be removed once
+        # -> Temporary test, should be removed once
         #    https://github.com/sphinx-gallery/sphinx-gallery/issues/241 is
         #    addressed and workaround is removed
         - os: linux
           env: SETUP_CMD='build_docs'
-               PIP_DEPENDENCIES='sphinx-gallery requests'
                CONDA_CHANNELS='conda-forge' PYTHON_VERSION=3.5
                TEST_CMD='python -c "import sphinx; assert int(sphinx.__version__[2])<6"'
-        - os: linux
-          env: SETUP_CMD='build_docs'
-               PIP_DEPENDENCIES='requests' CONDA_DEPENDENCIES='pytest'
-               CONDA_CHANNELS='conda-forge' PYTHON_VERSION=3.5
-               TEST_CMD='python -c "import sphinx; assert int(sphinx.__version__[2])>=6"'
 
         # -> Starting with the dev versions as they take the longest to run. We
         #    deliberately test with Numpy 1.9 to check that installing Astropy

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -265,9 +265,10 @@ if [[ $SETUP_CMD == build_sphinx* ]] || [[ $SETUP_CMD == build_docs* ]]; then
     fi
 
     # Temporary version limitation until
-    # https://github.com/sphinx-gallery/sphinx-gallery/issues/241 is addressed
-    if [[ -z $SPHINX_VERSION ]] && [[ ! -z $(echo $PIP_DEPENDENCIES $CONDA_DEPENDENCIES | \
-            grep sphinx-gallery) ]]; then
+    # https://github.com/sphinx-gallery/sphinx-gallery/issues/241 is
+    # addressed as well as packages are using astropy-helpers v2.0 that uses
+    # a fixed sphinx-automodapi version
+    if [[ -z $SPHINX_VERSION ]]; then
         SPHINX_VERSION='<1.6'
     fi
 


### PR DESCRIPTION
The sphinx 1.6.1 incompatibility is not only affects ``sphinx-gallery`` but ``sphinx-automodapi`` as well, astropy-helpers v2.0 will have the fix included.