### PR TITLE
Using astropy-ci-extras channel for pytest install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,8 +78,8 @@ matrix:
         # -> Setting pytest version should be recognized in the next two jobs
         - os: linux
           env: SETUP_CMD='build_sphinx' CONDA_DEPENDENCIES='matplotlib<=1.5.0'
-               DEBUG=True PYTHON_VERSION=2.7 PYTEST_VERSION=2.8
-               TEST_CMD='python -c "import matplotlib; assert matplotlib.__version__==\"1.5.0\"; import pytest; assert pytest.__version__.startswith(\"2.8\")"'
+               DEBUG=True PYTHON_VERSION=2.7 PYTEST_VERSION=2.7.3
+               TEST_CMD='python -c "import matplotlib; assert matplotlib.__version__==\"1.5.0\"; import pytest; assert pytest.__version__.startswith(\"2.7.3\")"'
 
         - os: linux
           env: SETUP_CMD='build_sphinx' SPHINX_VERSION=1.4.1 DEBUG=True

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -104,7 +104,9 @@ if [[ ! -z $PIP_VERSION ]]; then
     echo "pip ${PIP_VERSION}*" >> $PIN_FILE
 fi
 
-conda install $QUIET pytest pip
+# We use the channel astropy-ci-extras to host pytest 2.7.3 that is
+# compatible with LTS 1.0.x astropy
+conda install -c astropy-ci-extras $QUIET pytest pip
 
 export PIP_INSTALL='pip install'
 


### PR DESCRIPTION
Astropy 1.0.x (and thus everything that uses LTS astropy) on python3.5 requires pytest 2.7.3 and that is not available on either the default or conda-forge channels, so we built it on astropy-ci-extras.