### PR TITLE
Fixing some issues with the pip install fallbacks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,12 @@ env:
 
 matrix:
     include:
+        # -> Test falling back on pip when conda install is not working.
+        # Here healpy is not available with numpy 1.13
+        - os: linux
+          env: NUMPY_VERSION=stable CONDA_DEPENDENCIES='healpy'
+               CONDA_CHANNELS='conda-forge' DEBUG=True
+
         # -> Temporary test, should be removed once
         #    https://github.com/sphinx-gallery/sphinx-gallery/issues/241 is
         #    addressed and workaround is removed

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -299,7 +299,7 @@ if [[ $SETUP_CMD == build_sphinx* ]] || [[ $SETUP_CMD == build_docs* ]]; then
                 PIP_PACKAGE_VERSION='='${PIP_PACKAGE_VERSION}
             fi
             $PIP_INSTALL ${package}${PIP_PACKAGE_VERSION}
-            awk -v package=$package'{if ($1 != package) print $0}' /tmp/pin_file_copy > $PIN_FILE
+            awk -v package=$package '{if ($1 != package) print $0}' /tmp/pin_file_copy > $PIN_FILE
         )
     done
 
@@ -316,8 +316,7 @@ if [[ ! -z $CONDA_DEPENDENCIES ]]; then
         cp $PIN_FILE /tmp/pin_copy
         for package in $(echo $CONDA_DEPENDENCIES); do
             # We need to avoid other dependencies picked up from the pin file
-            echo $CONDA_DEPENDENCIES | tr " " "\n" | grep -vx $package > /tmp/dependency_subset
-            grep -vxf /tmp/dependency_subset /tmp/pin_copy > $PIN_FILE
+            awk -v package=$package '{if ($1 == package) print $0}' /tmp/pin_copy > $PIN_FILE
             if [[ $DEBUG == True ]]; then
                 cat $PIN_FILE
             fi

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -292,13 +292,13 @@ if [[ $SETUP_CMD == build_sphinx* ]] || [[ $SETUP_CMD == build_docs* ]]; then
 
         $CONDA_INSTALL $package && mv /tmp/pin_file_copy $PIN_FILE || ( \
             echo "Installing $package with conda was unsuccessful, using pip instead."
-            PIP_${package}_VERSION=$(awk '{print $2}' $PIN_FILE)
-            if [[ $(echo $PIP_${package}_VERSION | cut -c 1) =~ $is_number ]]; then
-                PIP_${package}_VERSION='=='${PIP_${package}_VERSION}
-            elif [[ $(echo $PIP_${package}_VERSION | cut -c 1-2) =~ $is_eq_number ]]; then
-                PIP_${package}_VERSION='='${PIP_${package}_VERSION}
+            PIP_PACKAGE_VERSION=$(awk '{print $2}' $PIN_FILE)
+            if [[ $(echo $PIP_PACKAGE_VERSION | cut -c 1) =~ $is_number ]]; then
+                PIP_PACKAGE_VERSION='=='${PIP_${package}_VERSION}
+            elif [[ $(echo $PIP_PACKAGE_VERSION | cut -c 1-2) =~ $is_eq_number ]]; then
+                PIP_PACKAGE_VERSION='='${PIP_PACKAGE_VERSION}
             fi
-            $PIP_INSTALL ${package}${PIP_${package}_VERSION}
+            $PIP_INSTALL ${package}${PIP_PACKAGE_VERSION}
             awk -v package=$package'{if ($1 != package) print $0}' /tmp/pin_file_copy > $PIN_FILE
         )
     done


### PR DESCRIPTION
We shouldn't install every dependency that is listed in the pinfile when installing default dependencies (e.g mpl and sphinx for the docs).

This PR also deals with some bugs that caused failing builds when only one package was listed as dependency and it failed to install. Hopefully this will provide a solution for some of the failing builds in https://github.com/hipspy/hips/issues/6