### PR TITLE
Numpy stable version updated to 1.13

### DIFF
--- a/appveyor/install-miniconda.ps1
+++ b/appveyor/install-miniconda.ps1
@@ -7,7 +7,7 @@ $MINICONDA_URL = "https://repo.continuum.io/miniconda/"
 
 $env:ASTROPY_LTS_VERSION = "1.0"
 $env:LATEST_ASTROPY_STABLE = "1.3"
-$env:LATEST_NUMPY_STABLE = "1.12"
+$env:LATEST_NUMPY_STABLE = "1.13"
 
 # We pin the version for conda as it's not the most stable package from
 # release to release. Add note here if version is pinned due to a bug upstream.

--- a/test_env.py
+++ b/test_env.py
@@ -28,10 +28,10 @@ if 'TRAVIS_REPO_SLUG' in os.environ:
 # The test scripts accept 'stable' for ASTROPY_VERSION to test that it's
 # properly parsed hard-wire the latest stable branch version here
 
-LATEST_ASTROPY_STABLE = '1.3'
+LATEST_ASTROPY_STABLE = '1.3.3'
 LATEST_ASTROPY_STABLE_WIN = '1.3'
 LATEST_ASTROPY_LTS = '1.0'
-LATEST_NUMPY_STABLE = '1.12'
+LATEST_NUMPY_STABLE = '1.13'
 
 if os.environ.get('PIP_DEPENDENCIES', None) is not None:
     PIP_DEPENDENCIES = os.environ['PIP_DEPENDENCIES'].split(' ')

--- a/travis/setup_conda.sh
+++ b/travis/setup_conda.sh
@@ -7,6 +7,8 @@
 #
 # The present script was added later.
 
+echo "=== Starting install for commit: ${TRAVIS_COMMIT} with commit message: ${TRAVIS_COMMIT_MESSAGE} ==="
+
 if [[ $DEBUG == True ]]; then
     set -x
 fi

--- a/travis/setup_conda.sh
+++ b/travis/setup_conda.sh
@@ -42,4 +42,8 @@ elif [[ ! -z $(echo $TRAVIS_COMMIT_MESSAGE | grep -E "$DOCS_ONLY") ]]; then
     fi
 fi
 
+echo "==================== Starting executing ci-helpers scripts ====================="
+
 source ci-helpers/travis/setup_conda_$TRAVIS_OS_NAME.sh;
+
+echo "================= Returning executing local .travis.yml script ================="

--- a/travis/setup_conda_linux.sh
+++ b/travis/setup_conda_linux.sh
@@ -1,18 +1,5 @@
 #!/bin/bash
 
-# Skip build if the commit message contains [skip travis] or [travis skip]
-# Remove workaround once travis has this feature natively
-# https://github.com/travis-ci/travis-ci/issues/5032
-echo "$TRAVIS_COMMIT_MESSAGE" | grep -E  '\[(skip travis|travis skip)\]' \
-    && echo "[skip travis] has been found, exiting." && exit 0
-
-
-if [[ $DEBUG == True ]]; then
-    set -x
-fi
-
-echo "==================== Starting executing ci-helpers scripts ====================="
-
 # Install conda
 # http://conda.pydata.org/docs/travis.html#the-travis-yml-file
 wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
@@ -26,5 +13,3 @@ if [[ $SETUP_XVFB == True ]]; then
     export DISPLAY=:99.0
     sh -e /etc/init.d/xvfb start
 fi
-
-echo "================= Returning executing local .travis.yml script ================="

--- a/travis/setup_conda_osx.sh
+++ b/travis/setup_conda_osx.sh
@@ -1,23 +1,11 @@
 #!/bin/bash
 
-# Skip build if the commit message contains [skip travis] or [travis skip]
-# Remove workaround once travis has this feature natively
-# https://github.com/travis-ci/travis-ci/issues/5032
-echo "$TRAVIS_COMMIT_MESSAGE" | grep -E  '\[(skip travis|travis skip)\]' \
-    && echo "[skip travis] has been found, exiting." && exit 0
-
-if [[ $DEBUG == True ]]; then
-    set -x
-fi
-
 # Workaround for https://github.com/travis-ci/travis-ci/issues/6307, which
 # caused the following error on MacOS X workers:
 #
 # /Users/travis/build.sh: line 109: shell_session_update: command not found
 #
 rvm get head
-
-echo "==================== Starting executing ci-helpers scripts ====================="
 
 # Install conda
 # http://conda.pydata.org/docs/travis.html#the-travis-yml-file
@@ -27,5 +15,3 @@ export PATH="$HOME/miniconda/bin:$PATH"
 
 # Install common Python dependencies
 source "$( dirname "${BASH_SOURCE[0]}" )"/setup_dependencies_common.sh
-
-echo "================= Returning executing local .travis.yml script ================="

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -20,7 +20,7 @@ shopt -s nocasematch
 
 export LATEST_ASTROPY_STABLE=1.3.3
 ASTROPY_LTS_VERSION=1.0
-LATEST_NUMPY_STABLE=1.12
+LATEST_NUMPY_STABLE=1.13
 
 if [[ $DEBUG == True ]]; then
     QUIET=''


### PR DESCRIPTION
In addition to the version update this PR also includes a minor cleanup in the travis scripts to remove code repetitions. As well as adding extra printouts to help debugging. Ideally these should have gone into  separate PR, but now merged into one to save on CI time.