### PR TITLE
Making sure to use the real commit message

### DIFF
--- a/travis/setup_conda.sh
+++ b/travis/setup_conda.sh
@@ -47,3 +47,5 @@ echo "==================== Starting executing ci-helpers scripts ===============
 source ci-helpers/travis/setup_conda_$TRAVIS_OS_NAME.sh;
 
 echo "================= Returning executing local .travis.yml script ================="
+
+set +x

--- a/travis/setup_conda.sh
+++ b/travis/setup_conda.sh
@@ -28,7 +28,16 @@ fi
 
 TR_SKIP="\[(skip travis|travis skip)\]"
 DOCS_ONLY="\[docs only|build docs\]"
-COMMIT_MESSAGE="$(git show -s ${TRAVIS_PULL_REQUEST_BRANCH} HEAD)"
+
+# Travis doesn't provide the commit message of the top of the branch for
+# PRs, only the commit message of the merge. Thus this ugly workaround is
+# needed for now.
+
+if [[ $TRAVIS_PULL_REQUEST == false ]]; then
+    COMMIT_MESSAGE=${TRAVIS_COMMIT_MESSAGE}
+else
+    COMMIT_MESSAGE=$(git show -s $TRAVIS_COMMIT_RANGE | awk 'BEGIN{count=0}{if ($1=="Author:") count++; if (count==1) print $0}')
+fi
 
 # Skip build if the commit message contains [skip travis] or [travis skip]
 # Remove workaround once travis has this feature natively

--- a/travis/setup_conda.sh
+++ b/travis/setup_conda.sh
@@ -28,14 +28,16 @@ fi
 
 TR_SKIP="\[(skip travis|travis skip)\]"
 DOCS_ONLY="\[docs only|build docs\]"
+COMMIT_MESSAGE="$(git show -s ${TRAVIS_PULL_REQUEST_BRANCH} HEAD)"
 
 # Skip build if the commit message contains [skip travis] or [travis skip]
 # Remove workaround once travis has this feature natively
 # https://github.com/travis-ci/travis-ci/issues/5032
-if [[ ! -z $(git show -s HEAD | grep -E "$TR_SKIP") ]]; then
+
+if [[ ! -z $(echo ${COMMIT_MESSAGE} | grep -E "${TR_SKIP}") ]]; then
     echo "Travis was requested to be skipped by the commit message, exiting."
     travis_terminate 0
-elif [[ ! -z $(git show -s HEAD | grep -E "$DOCS_ONLY") ]]; then
+elif [[ ! -z $(echo ${COMMIT_MESSAGE} | grep -E "${DOCS_ONLY}") ]]; then
     if [[ $SETUP_CMD != *build_docs* ]] && [[ $SETUP_CMD != *build_sphinx* ]]; then
         echo "Only docs build was requested by the commit message, exiting."
         travis_terminate 0


### PR DESCRIPTION
As travis does merge commits, we need to make sure to dig up the real commit message that is associated with the latest commit in a feature branch of a PR.