### PR TITLE
Removing sphinx version pinning of <1.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,14 +32,6 @@ matrix:
           env: NUMPY_VERSION=stable CONDA_DEPENDENCIES='healpy'
                CONDA_CHANNELS='conda-forge' DEBUG=True
 
-        # -> Temporary test, should be removed once
-        #    https://github.com/sphinx-gallery/sphinx-gallery/issues/241 is
-        #    addressed and workaround is removed
-        - os: linux
-          env: SETUP_CMD='build_docs'
-               CONDA_CHANNELS='conda-forge' PYTHON_VERSION=3.5
-               TEST_CMD='python -c "import sphinx; assert int(sphinx.__version__[2])<6"'
-
         # -> Testing whether pip install fallback is working for sphinx/matplotlib in the docs builds
         - os: linux
           env: SETUP_CMD='build_docs' SPHINX_VERSION='>1.6'

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -258,14 +258,6 @@ if [[ $SETUP_CMD == *build_sphinx* ]] || [[ $SETUP_CMD == *build_docs* ]]; then
         fi
     fi
 
-    # Temporary version limitation until
-    # https://github.com/sphinx-gallery/sphinx-gallery/issues/241 is
-    # addressed as well as packages are using astropy-helpers v2.0 that uses
-    # a fixed sphinx-automodapi version
-    if [[ -z $SPHINX_VERSION ]]; then
-        SPHINX_VERSION='<1.6'
-    fi
-
     if [[ ! -z $SPHINX_VERSION ]]; then
         if [[ -z $(grep sphinx $PIN_FILE) ]]; then
             echo "sphinx ${SPHINX_VERSION}*" >> $PIN_FILE


### PR DESCRIPTION
Merge this only once astropy-helpers v2.0 is out and merged in most affiliates.