### PR TITLE
Skip LTS testing when LTS==stable

### DIFF
--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -224,6 +224,12 @@ if [[ ! -z $ASTROPY_VERSION ]]; then
     elif [[ $ASTROPY_VERSION == stable ]]; then
         ASTROPY_OPTION=$LATEST_ASTROPY_STABLE
     elif [[ $ASTROPY_VERSION == lts ]]; then
+        # We ship the build if the LTS version is the same as latest stable
+        if [[ $LATEST_ASTROPY_STABLE == ${ASTROPY_LTS_VERSION}* ]]; then
+            echo "The latest stable version of astropy is an LTS version, skipping testing as LTS"
+            travis_terminate 0
+        fi
+
         # We add astropy to the pin file to make sure it won't get updated
         echo "astropy ${ASTROPY_LTS_VERSION}*" >> $PIN_FILE
         ASTROPY_OPTION=$ASTROPY_LTS_VERSION


### PR DESCRIPTION
I think it makes sense to not duplicate testing efforts when LTS astropy becomes the latest stable version without the need to manually weed out those jobs from the travis matrices (even though cancelling the builds this way means that half of the installation already happened). It may be possible to do the check a bit further up though in ``setup_conda.py``, but that may mess up things for repos that are still using the OS dependent version of the scripts.

Can't test now without messing up everything with changing the version.

cc @astrofrog

