### PR TITLE
Disabling channel priority for pytest install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,14 @@ env:
 
 matrix:
     include:
+        # -> even if CHANNEL_PRIORITY is true then the old pytest shouldn't
+        #     be picked up from the astropy-ci-extras channel.
+        - os: linux
+          env: CONDA_PRIORITY=True CONDA_CHANNELS='conda-forge'
+               TEST_CMD='python -c "import pytest; assert pytest.__version__.startswith(\"3.\")"'
+
         # -> Test falling back on pip when conda install is not working.
-        # Here healpy is not available with numpy 1.13
+        #    Here healpy is not available with numpy 1.13
         - os: linux
           env: NUMPY_VERSION=stable CONDA_DEPENDENCIES='healpy'
                CONDA_CHANNELS='conda-forge' DEBUG=True

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -94,8 +94,10 @@ if [[ ! -z $PIP_VERSION ]]; then
 fi
 
 # We use the channel astropy-ci-extras to host pytest 2.7.3 that is
-# compatible with LTS 1.0.x astropy
-conda install -c astropy-ci-extras $QUIET pytest pip
+# compatible with LTS 1.0.x astropy. We need to disable channel priority for
+# this step to make sure the latest version is picked up when
+# CHANNEL_PRIORITY is set to True above.
+conda install -c astropy-ci-extras --no-channel-priority $QUIET pytest pip
 
 export PIP_INSTALL='pip install'
 


### PR DESCRIPTION
This is to fix #210 