### PR TITLE
auto install pytest-cov

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -127,6 +127,10 @@ matrix:
           env: MAIN_CMD='pylint'
                TEST_CMD='pylint --version'
 
+        - os: linux
+          env: SETUP_CMD="--cov package"
+               TEST_CMD='python -c "import pytest_cov"'
+
         # -> Don't test osx with LTS as we currently build LTS only for linux.
         - os: osx
           env: SETUP_CMD='test' ASTROPY_VERSION=stable

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ environment variables
     * ``--coverage``: the coverage and coveralls packages are installed
     * ``--parallel``: the pytest-xdist package is installed
     * ``--open-files``: the psutil package is installed
+    * ``--cov``: the pytest-cov package is installed
 
 * ``$NUMPY_VERSION``: if set to ``dev`` or ``development``, the latest
   developer version of Numpy is installed along with Cython. If set to a

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -411,7 +411,7 @@ if [[ $SETUP_CMD == *coverage* ]]; then
     $PIP_INSTALL coveralls
 fi
 
-if [[ $SETUP_CMP == *--cov* ]]; then
+if [[ $SETUP_CMD == *--cov* ]]; then
     $CONDA_INSTALL pytest-cov
 fi
 

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -411,6 +411,10 @@ if [[ $SETUP_CMD == *coverage* ]]; then
     $PIP_INSTALL coveralls
 fi
 
+if [[ $SETUP_CMP == *--cov* ]]; then
+    $CONDA_INSTALL pytest-cov
+fi
+
 
 # SPHINX BUILD MPL FONT CACHING WORKAROUND
 


### PR DESCRIPTION
If "--cov" is found in the `SETUP_CMD` variable install pytest-cov module from
conda.

fixes: #214