### PR TITLE
install pytest-xdist when --numprocesses is detected

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -169,6 +169,10 @@ matrix:
                TEST_CMD='py.test -n 4 test_env.py'
 
         - os: linux
+          env: SETUP_CMD='test --numprocesses'
+               TEST_CMD='py.test --numprocesses 4 test_env.py'
+
+        - os: linux
           env: SETUP_CMD='test --open-files'
 
         - os: linux

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ environment variables
   In addition, if ``SETUP_CMD`` contains the following flags, extra dependencies are installed:
 
     * ``--coverage``: the coverage and coveralls packages are installed
-    * ``--parallel``: the pytest-xdist package is installed
+    * ``--parallel`` or ``--numprocesses``: the pytest-xdist package is installed
     * ``--open-files``: the psutil package is installed
     * ``--cov``: the pytest-cov package is installed
 

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -324,7 +324,7 @@ if [[ ! -z $CONDA_DEPENDENCIES ]]; then
 fi
 
 # PARALLEL BUILDS
-if [[ $SETUP_CMD == *parallel* ]]; then
+if [[ $SETUP_CMD == *parallel* || $SETUP_CMD == *numprocesses* ]]; then
     $PIP_INSTALL pytest-xdist
 fi
 


### PR DESCRIPTION
fixes #213 

A new pytest-xdist version  has been released with the new option. This is now checking for the `numprocesses` flag and installing pytest-xdist. Unfortunately this will only work with pytest-xdist>1.18.0 so when a person is pinning a lower version it will fails. But I'm not sure how much of a problem that is in practice since pinning will cause pytest-xdist to be installed anyway.