### PR TITLE
Updating conda version to the latest release, 4.3.21

### DIFF
--- a/appveyor/install-miniconda.ps1
+++ b/appveyor/install-miniconda.ps1
@@ -24,7 +24,7 @@ $env:LATEST_NUMPY_STABLE = "1.13"
 # We pin the version for conda as it's not the most stable package from
 # release to release. Add note here if version is pinned due to a bug upstream.
 if (! $env:CONDA_VERSION) {
-   $env:CONDA_VERSION = "4.3.6"
+   $env:CONDA_VERSION = "4.3.21"
 }
 
 function DownloadMiniconda ($version, $platform_suffix) {

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -39,7 +39,7 @@ fi
 # We pin the version for conda as it's not the most stable package from
 # release to release. Add note here if version is pinned due to a bug upstream.
 if [[ -z $CONDA_VERSION ]]; then
-    CONDA_VERSION=4.3.6
+    CONDA_VERSION=4.3.21
 fi
 
 PIN_FILE_CONDA=$HOME/miniconda/conda-meta/pinned


### PR DESCRIPTION
I've tested this on travis for astropy and photutils and seems to be working. However we should hold off merging a bit to get a feedback on https://github.com/conda/conda/issues/5774 where I run into issues with ``conda install conda`` for a few buillds. 

However they're working now after a restart.