### PR TITLE
Custom version tags for sunpy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,11 +32,13 @@ matrix:
           env: CONDA_PRIORITY=True CONDA_CHANNELS='conda-forge'
                TEST_CMD='python -c "import pytest; assert pytest.__version__.startswith(\"3.\")"'
 
+        # -> tests sunpy stable
         # -> Test falling back on pip when conda install is not working.
         #    Here healpy is not available with numpy 1.13
         - os: linux
           env: NUMPY_VERSION=stable CONDA_DEPENDENCIES='healpy'
                CONDA_CHANNELS='conda-forge' DEBUG=True
+               SUNPY_VERSION=stable
 
         # -> Temporary test, should be removed once
         #    https://github.com/sphinx-gallery/sphinx-gallery/issues/241 is
@@ -52,12 +54,13 @@ matrix:
                PYTHON_VERSION=3.5
                TEST_CMD='python -c "import sphinx; assert int(sphinx.__version__[2])>5"'
 
+        # -> tests sunpy dev
         # -> Starting with the dev versions as they take the longest to run. We
         #    deliberately test with Numpy 1.9 to check that installing Astropy
         #    dev doesn't upgrade Numpy.
         - os: linux
           env: SETUP_CMD='test' NUMPY_VERSION=1.9 ASTROPY_VERSION=dev
-               PYTHON_VERSION=3.5
+               PYTHON_VERSION=3.5 SUNPY_VERSION=dev CONDA_CHANNELS='conda-forge'
 
         # -> For the Numpy dev build, we also specify a conda package that
         #    depends on Numpy to make sure that Numpy dev is used (because
@@ -81,16 +84,14 @@ matrix:
                CONDA_DEPENDENCIES='pyqt5 openjpeg photutils pytest pytest-cov'
                DEBUG=True NUMPY_VERSION=1.10 ASTROPY_VERSION=lts
 
-        # -> The pre build only should run to the testing phase if a pre
-        #    release is available for numpy on pypi, otherwise it should pass
+        # -> The pre builds should run the testing phase only when a pre
+        #    release is available on pypi, otherwise it should pass
         - os: linux
           env: SETUP_CMD='test' NUMPY_VERSION=pre
-               CONDA_DEPENDENCIES='scipy' DEBUG=True
-
-        # -> The pre build only should run to the testing phase if a pre
-        #    release is available for astropy on pypi, otherwise it should pass
         - os: linux
           env: SETUP_CMD='test' ASTROPY_VERSION=pre DEBUG=True
+        - os: linux
+          env: SUNPY_VERSION=prerelease CONDA_CHANNELS='conda-forge'
 
         # -> Setting pytest version should be recognized in the next two jobs
         - os: linux

--- a/README.md
+++ b/README.md
@@ -90,6 +90,13 @@ environment variables
   found
   [here](https://github.com/astropy/astropy-APEs/blob/master/APE2.rst#version-numbering).
 
+* ``$SUNPY_VERSION``: if set to ``dev`` or ``development``, the latest
+  developer version of Sunpy is installed. If set to a
+  version number, that version is installed. If set to ``stable``, install
+  the latest stable version of Sunpy. If set to ``prerelease``, the
+  pre-release version of Sunpy gets installed if there is any, otherwise the
+  build exits and passes on Travis without running the tests.
+
 * ``$CONDA_DEPENDENCIES``: this should be a space-separated string of
   package names that will be installed with conda. Version numbers of these
   dependencies can be overridden/specified with the ``$PACKAGENAME_VERSION``

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,6 +24,7 @@ environment:
         PIP_DEPENDENCIES: "requests pyparsing"
         CONDA_CHANNEL_PRIORITY: "True"
         DEBUG: "True"
+        SUNPY_VERSION: "stable"
 
       - PYTHON_VERSION: "3.6"
         NUMPY_VERSION: "stable"
@@ -31,6 +32,7 @@ environment:
         CONDA_DEPENDENCIES: "matplotlib h5py"
         PIP_DEPENDENCIES: "astrodendro"
         CONDA_CHANNEL_PRIORITY: "False"
+        SUNPY_VERSION: "dev"
 
       - PYTHON_VERSION: "2.7"
         DEBUG: "True"

--- a/appveyor/install-miniconda.ps1
+++ b/appveyor/install-miniconda.ps1
@@ -20,6 +20,7 @@ $MINICONDA_URL = "https://repo.continuum.io/miniconda/"
 $env:ASTROPY_LTS_VERSION = "2.0.1"
 $env:LATEST_ASTROPY_STABLE = "2.0.1"
 $env:LATEST_NUMPY_STABLE = "1.13"
+$env:LATEST_SUNPY_STABLE = "0.7.9"
 
 # We pin the version for conda as it's not the most stable package from
 # release to release. Add note here if version is pinned due to a bug upstream.
@@ -174,6 +175,25 @@ if ($env:ASTROPY_VERSION) {
     $ASTROPY_OPTION = ""
 }
 
+# Check whether a specific version of Sunpy is required
+if ($env:SUNPY_VERSION) {
+    if($env:SUNPY_VERSION -match "stable") {
+        $SUNPY_OPTION = "sunpy"
+    } elseif($env:SUNPY_VERSION -match "dev") {
+        $SUNPY_OPTION = ""
+    } else {
+        $SUNPY_OPTION = "sunpy=" + $env:SUNPY_VERSION
+    }
+    $output = cmd /c conda install -n test -q $NUMPY_OPTION $SUNPY_OPTION 2>&1
+    echo $output
+    if ($output | select-string UnsatisfiableError) {
+       echo "Installing sunpy with conda was unsuccessful, using pip instead"
+       pip install $SUNPY_OPTION
+    }
+} else {
+    $SUNPY_OPTION = ""
+}
+
 # Install the specified versions of numpy and other dependencies
 if ($env:CONDA_DEPENDENCIES) {
     $CONDA_DEPENDENCIES = $env:CONDA_DEPENDENCIES.split(" ")
@@ -203,6 +223,12 @@ if ($env:NUMPY_VERSION -match "dev") {
 # it. We need to include --no-deps to make sure that Numpy doesn't get upgraded.
 if ($env:ASTROPY_VERSION -match "dev") {
    Invoke-Expression "${env:CMD_IN_ENV} pip install git+https://github.com/astropy/astropy.git#egg=astropy --upgrade --no-deps"
+}
+
+# Check whether the developer version of Sunpy is required and if yes install
+# it. We need to include --no-deps to make sure that Numpy doesn't get upgraded.
+if ($env:SUNPY_VERSION -match "dev") {
+   Invoke-Expression "${env:CMD_IN_ENV} pip install git+https://github.com/sunpy/sunpy.git#egg=sunpy --upgrade --no-deps"
 }
 
 # We finally install the dependencies listed in PIP_DEPENDENCIES. We do this

--- a/test_env.py
+++ b/test_env.py
@@ -36,6 +36,7 @@ LATEST_ASTROPY_STABLE = '2.0.1'
 LATEST_ASTROPY_STABLE_WIN = '2.0.1'
 LATEST_ASTROPY_LTS = '2.0.1'
 LATEST_NUMPY_STABLE = '1.13'
+LATEST_SUNPY_STABLE = '0.7.9'
 
 if os.environ.get('PIP_DEPENDENCIES', None) is not None:
     PIP_DEPENDENCIES = os.environ['PIP_DEPENDENCIES'].split(' ')
@@ -99,6 +100,22 @@ def test_astropy():
             else:
                 assert astropy.__version__.startswith(os_astropy_version)
             assert 'dev' not in astropy.__version__
+
+
+def test_sunpy():
+    if 'SUNPY_VERSION' in os.environ:
+        import sunpy
+        os_sunpy_version = os.environ['SUNPY_VERSION'].lower()
+        if 'dev' in os_sunpy_version:
+            assert 'dev' in sunpy.__version__
+        else:
+            if 'pre' in os_sunpy_version:
+                assert re.match("[0-9.]*[0-9](rc[0-9])", sunpy.__version__)
+            elif 'stable' in os_sunpy_version:
+                assert sunpy.__version__.startswith(LATEST_SUNPY_STABLE)
+            else:
+                assert sunpy.__version__.startswith(os_sunpy_version)
+            assert 'dev' not in sunpy.__version__
 
 
 # Check whether everything is installed and importable


### PR DESCRIPTION
This partially deals with #220. If this works, a generalization can be worked on. The only bottleneck is that the version number for the stable releases are hard-wired. If we want to generalize the understanding of "stable" and "dev" for arbitrarily packages, then we need another, more robust solution (e.g. checking pypi for the latest version, but that possibly opens up whole can of worms).

cc @Cadair @nabobalis