### PR TITLE
Removing sphinx version limitation of <1.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,14 +44,6 @@ matrix:
                CONDA_CHANNELS='conda-forge' DEBUG=True
                SUNPY_VERSION=stable
 
-        # -> Temporary test, should be removed once
-        #    https://github.com/sphinx-gallery/sphinx-gallery/issues/241 is
-        #    addressed and workaround is removed
-        - os: linux
-          env: SETUP_CMD='build_docs'
-               CONDA_CHANNELS='conda-forge' PYTHON_VERSION=3.5
-               TEST_CMD='python -c "import sphinx; assert int(sphinx.__version__[2])<6"'
-
         # -> Testing whether pip install fallback is working for sphinx/matplotlib in the docs builds
         - os: linux
           env: SETUP_CMD='build_docs' SPHINX_VERSION='>1.6'

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -318,14 +318,6 @@ if [[ $SETUP_CMD == *build_sphinx* ]] || [[ $SETUP_CMD == *build_docs* ]]; then
         fi
     fi
 
-    # Temporary version limitation until
-    # https://github.com/sphinx-gallery/sphinx-gallery/issues/241 is
-    # addressed as well as packages are using astropy-helpers v2.0 that uses
-    # a fixed sphinx-automodapi version
-    if [[ -z $SPHINX_VERSION ]]; then
-        SPHINX_VERSION='<1.6'
-    fi
-
     if [[ ! -z $SPHINX_VERSION ]]; then
         if [[ -z $(grep sphinx $PIN_FILE) ]]; then
             echo "sphinx ${SPHINX_VERSION}*" >> $PIN_FILE


### PR DESCRIPTION
A support for newer versions are released in astropy-helpers 2.0, a couple of months ago. 

If you use sphinx-gallery, it's best to require at least 0.1.11 (that was released in May, and contains a fix for the same sphinx 1.6+ issue).