### PR TITLE
DOC recommend using shallow clones in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Include the following lines at the start of the ``install`` section in ``.travis
 
 ```yaml
 install:
-    - git clone git://github.com/astropy/ci-helpers.git
+    - git clone --depth 1 git://github.com/astropy/ci-helpers.git
     - source ci-helpers/travis/setup_conda.sh
 ```
 
@@ -182,7 +182,7 @@ Include the following lines at the start of the ``install`` section in ``appveyo
 
 ```yaml
 install:
-    - "git clone git://github.com/astropy/ci-helpers.git"
+    - "git clone --depth 1 git://github.com/astropy/ci-helpers.git"
     - "powershell ci-helpers/appveyor/install-miniconda.ps1"
     - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
     - "activate test"


### PR DESCRIPTION
Recommend using shallow clones in the README ( cf. https://github.com/astropy/ci-helpers/issues/229 ).

The difference is a 20k download size as compared to 340k for the full git history. Also reduced the run time of this step from 1s to 0.5s on my laptop...