### PR TITLE
Make pip install fallback optional

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,8 +30,10 @@ matrix:
         - os: linux
           env: PYTHON_VERSION=3.4 PYTEST_VERSION=3.1
 
-        # Try pytest pip fallback as conda package for 3.1 is not available for py3.4 but
-        # then fail as PIP_FALLBACK is False
+        # Try pytest pip fallback as conda package for 3.1 is not available
+        # for py3.4 but then fail as PIP_FALLBACK is False. Listing this
+        # under the allowed failures as there is no way at the moment to
+        # require it to fail.
         - os: linux
           env: PYTHON_VERSION=3.4 PYTEST_VERSION=3.1 PIP_FALLBACK=false
 
@@ -192,6 +194,10 @@ matrix:
         - os: linux
           env: SETUP_CMD='test' CONDA_ENVIRONMENT='conda_environment.yml' CONDA_DEPENDENCIES="scipy"
                TEST_CMD="python -c $'import matplotlib\nimport scipy'"
+
+    allow_failures:
+        - os: linux
+          env: PYTHON_VERSION=3.4 PYTEST_VERSION=3.1 PIP_FALLBACK=false
 
 before_install:
     - ln -s . ci-helpers

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,9 +26,14 @@ env:
 
 matrix:
     include:
-        # pytest pip fallback, conda package for 3.2 is not available for py3.4
+        # pytest pip fallback, conda package for 3.1 is not available for py3.4
         - os: linux
           env: PYTHON_VERSION=3.4 PYTEST_VERSION=3.1
+
+        # Try pytest pip fallback as conda package for 3.1 is not available for py3.4 but
+        # then fail as PIP_FALLBACK is False
+        - os: linux
+          env: PYTHON_VERSION=3.4 PYTEST_VERSION=3.1 PIP_FALLBACK=false
 
         # -> even if CHANNEL_PRIORITY is true then the old pytest shouldn't
         #     be picked up from the astropy-ci-extras channel.

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,10 +52,10 @@ matrix:
 
         # -> tests sunpy dev
         # -> Starting with the dev versions as they take the longest to run. We
-        #    deliberately test with Numpy 1.9 to check that installing Astropy
+        #    deliberately test with Numpy 1.10 to check that installing Astropy
         #    dev doesn't upgrade Numpy.
         - os: linux
-          env: SETUP_CMD='test' NUMPY_VERSION=1.9 ASTROPY_VERSION=dev
+          env: SETUP_CMD='test' NUMPY_VERSION=1.10 ASTROPY_VERSION=dev
                PYTHON_VERSION=3.5 SUNPY_VERSION=dev CONDA_CHANNELS='conda-forge'
 
         # -> For the Numpy dev build, we also specify a conda package that

--- a/README.md
+++ b/README.md
@@ -145,6 +145,9 @@ environment variables
   run only on pushes to master, or for Travis cron jobs. Valid event types
   are: ``push``, ``pull_request``, ``api`` or ``cron``.
 
+* ``$PIP_FALLBACK``: the default behaviour is to fall back to try to pip
+  install a package if installing it with conda fails for any reason. Set
+  this variable to ``false`` to opt out of this.
 
 The idea behind the ``MAIN_CMD`` and ``SETUP_CMD`` environment variables is
 that the ``script`` section of the ``.travis.yml`` file can be set to:
@@ -211,11 +214,24 @@ Following this, various dependencies are installed depending on the following en
   version is installed (more info about LTS can be found
   [here](https://github.com/astropy/astropy-APEs/blob/master/APE2.rst#version-numbering)).
 
+* ``$SUNPY_VERSION``: if set to ``dev`` or ``development``, the latest
+  developer version of Sunpy is installed. If set to a
+  version number, that version is installed. If set to ``stable``, install
+  the latest stable version of Sunpy.
+
 * ``$CONDA_DEPENDENCIES``: this should be a space-separated string of package
   names that will be installed with conda.
 
 * ``$CONDA_CHANNELS``: this should be a space-separated string of conda
   channel names. We don't add any channel by default.
+
+* ``$DEBUG``: if `True` this turns on the shell debug mode in the install
+  scripts, and provides information on the current conda install and
+  switches off the ``-q`` conda flag for verbose output.
+
+* ``$PIP_FALLBACK``: the default behaviour is to fall back to try to pip
+  install a package if installing it with conda fails for any reason. Set
+  this variable to ``false`` to opt out of this.
 
 Details
 -------

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -44,10 +44,10 @@ environment:
       - PYTHON_VERSION: "3.4"
         NUMPY_VERSION: "1.9"
 
-        # We deliberately test with Numpy 1.9 to check that installing Astropy
+        # We deliberately test with Numpy 1.10 to check that installing Astropy
         # dev doesn't upgrade Numpy.
       - PYTHON_VERSION: "3.5"
-        NUMPY_VERSION: "1.9"
+        NUMPY_VERSION: "1.10"
         ASTROPY_VERSION: "development"
 
       - PYTHON_VERSION: "3.5"

--- a/appveyor/install-miniconda.ps1
+++ b/appveyor/install-miniconda.ps1
@@ -203,7 +203,7 @@ if ($env:ASTROPY_VERSION) {
     }
     $output = cmd /c conda install -n test $QUIET $NUMPY_OPTION $ASTROPY_OPTION 2>&1
     echo $output
-    if ($output | select-string UnsatisfiableError) -and $env:PIP_FALLBACK {
+    if (($output | select-string UnsatisfiableError) -and $env:PIP_FALLBACK) {
        echo "Installing astropy with conda was unsuccessful, using pip instead"
        pip install $ASTROPY_OPTION
        checkLastExitCode
@@ -225,7 +225,7 @@ if ($env:SUNPY_VERSION) {
     }
     $output = cmd /c conda install -n test $QUIET $NUMPY_OPTION $SUNPY_OPTION 2>&1
     echo $output
-    if ($output | select-string UnsatisfiableError) -and $env:PIP_FALLBACK {
+    if (($output | select-string UnsatisfiableError) -and $env:PIP_FALLBACK) {
        echo "Installing sunpy with conda was unsuccessful, using pip instead"
        pip install $SUNPY_OPTION
        checkLastExitCode
@@ -248,7 +248,7 @@ if ($NUMPY_OPTION -or $CONDA_DEPENDENCIES) {
 
   $output = cmd /c conda install -n test $QUIET $NUMPY_OPTION $CONDA_DEPENDENCIES 2>&1
   echo $output
-  if ($output | select-string UnsatisfiableError, PackageNotFoundError) -and $env:PIP_FALLBACK {
+  if (($output | select-string UnsatisfiableError, PackageNotFoundError) -and $env:PIP_FALLBACK) {
      echo "Installing dependencies with conda was unsuccessful, using pip instead"
      $output = cmd /c pip install $CONDA_DEPENDENCIES 2>&1
      echo $output

--- a/appveyor/install-miniconda.ps1
+++ b/appveyor/install-miniconda.ps1
@@ -42,6 +42,10 @@ if (! $env:CONDA_VERSION) {
    $env:CONDA_VERSION = "4.3.21"
 }
 
+if (! $env:PIP_FALLBACK) {
+   $env:PIP_FALLBACK = "True"
+}
+
 function DownloadMiniconda ($version, $platform_suffix) {
     $webclient = New-Object System.Net.WebClient
     $filename = "Miniconda3-" + $version + "-Windows-" + $platform_suffix + ".exe"
@@ -199,7 +203,7 @@ if ($env:ASTROPY_VERSION) {
     }
     $output = cmd /c conda install -n test $QUIET $NUMPY_OPTION $ASTROPY_OPTION 2>&1
     echo $output
-    if ($output | select-string UnsatisfiableError) {
+    if ($output | select-string UnsatisfiableError) -and $env:PIP_FALLBACK {
        echo "Installing astropy with conda was unsuccessful, using pip instead"
        pip install $ASTROPY_OPTION
        checkLastExitCode
@@ -221,7 +225,7 @@ if ($env:SUNPY_VERSION) {
     }
     $output = cmd /c conda install -n test $QUIET $NUMPY_OPTION $SUNPY_OPTION 2>&1
     echo $output
-    if ($output | select-string UnsatisfiableError) {
+    if ($output | select-string UnsatisfiableError) -and $env:PIP_FALLBACK {
        echo "Installing sunpy with conda was unsuccessful, using pip instead"
        pip install $SUNPY_OPTION
        checkLastExitCode
@@ -244,7 +248,7 @@ if ($NUMPY_OPTION -or $CONDA_DEPENDENCIES) {
 
   $output = cmd /c conda install -n test $QUIET $NUMPY_OPTION $CONDA_DEPENDENCIES 2>&1
   echo $output
-  if ($output | select-string UnsatisfiableError, PackageNotFoundError) {
+  if ($output | select-string UnsatisfiableError, PackageNotFoundError) -and $env:PIP_FALLBACK {
      echo "Installing dependencies with conda was unsuccessful, using pip instead"
      $output = cmd /c pip install $CONDA_DEPENDENCIES 2>&1
      echo $output

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -214,6 +214,7 @@ elif [[ $NUMPY_VERSION == pre* ]]; then
         # We want to stop the script if there isn't a pre-release available,
         # as in that case it would be just another build using the stable
         # version.
+        echo "Prerelease for numpy is not available, stopping test"
         travis_terminate 0
     fi
 elif [[ ! -z $NUMPY_VERSION ]]; then
@@ -237,6 +238,7 @@ if [[ ! -z $ASTROPY_VERSION ]]; then
             # We want to stop the script if there isn't a pre-release available,
             # as in that case it would be just another build using the stable
             # version.
+            echo "Prerelease for astropy is not available, stopping test"
             travis_terminate 0
         fi
     elif [[ $ASTROPY_VERSION == stable ]]; then
@@ -280,6 +282,7 @@ if [[ ! -z $SUNPY_VERSION ]]; then
             # We want to stop the script if there isn't a pre-release available,
             # as in that case it would be just another build using the stable
             # version.
+            echo "Prerelease for sunpy is not available, stopping test"
             travis_terminate 0
         fi
     elif [[ $SUNPY_VERSION == stable ]]; then

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -24,7 +24,7 @@ LATEST_NUMPY_STABLE=1.13
 LATEST_SUNPY_STABLE=0.8.1
 
 if [[ -z $PIP_FALLBACK ]]; then
-    PIP_FALLBACK=True
+    PIP_FALLBACK=true
 fi
 
 if [[ $DEBUG == True ]]; then

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -23,6 +23,9 @@ ASTROPY_LTS_VERSION=2.0.2
 LATEST_NUMPY_STABLE=1.13
 LATEST_SUNPY_STABLE=0.8.1
 
+if [[ -z $PIP_FALLBACK ]]; then
+    PIP_FALLBACK=True
+fi
 
 if [[ $DEBUG == True ]]; then
     QUIET=''
@@ -108,13 +111,14 @@ fi
 # this step to make sure the latest version is picked up when
 # CHANNEL_PRIORITY is set to True above.
 conda install -c astropy-ci-extras --no-channel-priority $QUIET pytest pip || ( \
+    $PIP_FALLBACK && ( \
     if [[ ! -z $PYTEST_VERSION ]]; then
         echo "Installing pytest with conda was unsuccessful, using pip instead"
         conda install $QUIET pip
         pip install pytest==$PYTEST_VERSION
         awk '{if ($1 != "pytest") print $0}' $PIN_FILE > /tmp/pin_file_temp
         mv /tmp/pin_file_temp $PIN_FILE
-     fi
+    fi)
 )
 
 export PIP_INSTALL='pip install'
@@ -260,12 +264,13 @@ if [[ ! -z $ASTROPY_VERSION ]]; then
     fi
     if [[ ! -z $ASTROPY_OPTION ]]; then
         conda install --no-pin $QUIET python=$PYTHON_VERSION $NUMPY_OPTION astropy=$ASTROPY_OPTION || ( \
+            $PIP_FALLBACK && ( \
             echo "Installing astropy with conda was unsuccessful, using pip instead"
             $PIP_INSTALL astropy==$ASTROPY_OPTION
             if [[ -f $PIN_FILE ]]; then
                 awk '{if ($1 != "astropy") print $0}' $PIN_FILE > /tmp/pin_file_temp
                 mv /tmp/pin_file_temp $PIN_FILE
-            fi)
+            fi))
     fi
 
 fi
@@ -294,12 +299,13 @@ if [[ ! -z $SUNPY_VERSION ]]; then
     fi
     if [[ ! -z $SUNPY_OPTION ]]; then
         conda install --no-pin $QUIET python=$PYTHON_VERSION $NUMPY_OPTION sunpy=$SUNPY_OPTION || ( \
+            $PIP_FALLBACK && ( \
             echo "Installing sunpy with conda was unsuccessful, using pip instead"
             $PIP_INSTALL sunpy==$SUNPY_OPTION
             if [[ -f $PIN_FILE ]]; then
                 awk '{if ($1 != "sunpy") print $0}' $PIN_FILE > /tmp/pin_file_temp
                 mv /tmp/pin_file_temp $PIN_FILE
-            fi)
+            fi))
     fi
 
 fi
@@ -335,6 +341,7 @@ if [[ $SETUP_CMD == *build_sphinx* ]] || [[ $SETUP_CMD == *build_docs* ]]; then
         awk -v package=$package '{if ($1 == package) print $0}' /tmp/pin_file_copy > $PIN_FILE
 
         $CONDA_INSTALL $package && mv /tmp/pin_file_copy $PIN_FILE || ( \
+            $PIP_FALLBACK && (\
             echo "Installing $package with conda was unsuccessful, using pip instead."
             PIP_PACKAGE_VERSION=$(awk '{print $2}' $PIN_FILE)
             if [[ $(echo $PIP_PACKAGE_VERSION | cut -c 1) =~ $is_number ]]; then
@@ -344,7 +351,7 @@ if [[ $SETUP_CMD == *build_sphinx* ]] || [[ $SETUP_CMD == *build_docs* ]]; then
             fi
             $PIP_INSTALL ${package}${PIP_PACKAGE_VERSION}
             awk -v package=$package '{if ($1 != package) print $0}' /tmp/pin_file_copy > $PIN_FILE
-        )
+        ))
     done
 
     if [[ $DEBUG == True ]]; then
@@ -356,6 +363,7 @@ fi
 # ADDITIONAL DEPENDENCIES (can include optionals, too)
 if [[ ! -z $CONDA_DEPENDENCIES ]]; then
     $CONDA_INSTALL $CONDA_DEPENDENCIES $CONDA_DEPENDENCIES_FLAGS || ( \
+        $PIP_FALLBACK && ( \
         # If there is a problem with conda install, try pip install one-by-one
         cp $PIN_FILE /tmp/pin_copy
         for package in $(echo $CONDA_DEPENDENCIES); do
@@ -373,7 +381,7 @@ if [[ ! -z $CONDA_DEPENDENCIES ]]; then
                 mv /tmp/pin_copy_temp /tmp/pin_copy
                 $PIP_INSTALL $package);
         done
-        mv /tmp/pin_copy $PIN_FILE)
+        mv /tmp/pin_copy $PIN_FILE))
 fi
 
 # PARALLEL BUILDS


### PR DESCRIPTION
This is to close #227 by adding a new env variable ``PIP_FALLBACK``. By default this is True, but no pip install fallback will happen if it's set to False.

The pr also contains the comment discussed in #239, thus close #239.