### PR TITLE
pip fallback should not upgrade dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,11 @@ env:
 
 matrix:
     include:
+        # making sure that falling back on pip install doesn't upgrade dependencies
+        # This combination need to fail as np1.8 is an unsupported version
+        - os: linux
+          env: PYTHON_VERSION=2.7 NUMPY_VERSION=1.8 ASTROPY_VERSION=2.0.2
+
         # pytest pip fallback, conda package for 3.1 is not available for py3.4
         - os: linux
           env: PYTHON_VERSION=3.4 PYTEST_VERSION=3.1

--- a/appveyor/install-miniconda.ps1
+++ b/appveyor/install-miniconda.ps1
@@ -205,7 +205,7 @@ if ($env:ASTROPY_VERSION) {
     echo $output
     if (($output | select-string UnsatisfiableError) -and $env:PIP_FALLBACK) {
        echo "Installing astropy with conda was unsuccessful, using pip instead"
-       pip install $ASTROPY_OPTION
+       pip install --upgrade-strategy only-if-needed $ASTROPY_OPTION
        checkLastExitCode
     } else {
       checkLastExitCode
@@ -227,7 +227,7 @@ if ($env:SUNPY_VERSION) {
     echo $output
     if (($output | select-string UnsatisfiableError) -and $env:PIP_FALLBACK) {
        echo "Installing sunpy with conda was unsuccessful, using pip instead"
-       pip install $SUNPY_OPTION
+       pip install --upgrade-strategy only-if-needed $SUNPY_OPTION
        checkLastExitCode
     } else {
       checkLastExitCode
@@ -250,7 +250,7 @@ if ($NUMPY_OPTION -or $CONDA_DEPENDENCIES) {
   echo $output
   if (($output | select-string UnsatisfiableError, PackageNotFoundError) -and $env:PIP_FALLBACK) {
      echo "Installing dependencies with conda was unsuccessful, using pip instead"
-     $output = cmd /c pip install $CONDA_DEPENDENCIES 2>&1
+     $output = cmd /c pip install --upgrade-strategy only-if-needed $CONDA_DEPENDENCIES 2>&1
      echo $output
      checkLastExitCode
      if ($output | select-string UnsatisfiableError, PackageNotFoundError) {

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -266,7 +266,7 @@ if [[ ! -z $ASTROPY_VERSION ]]; then
         conda install --no-pin $QUIET python=$PYTHON_VERSION $NUMPY_OPTION astropy=$ASTROPY_OPTION || ( \
             $PIP_FALLBACK && ( \
             echo "Installing astropy with conda was unsuccessful, using pip instead"
-            $PIP_INSTALL astropy==$ASTROPY_OPTION
+            $PIP_INSTALL --upgrade-strategy only-if-needed astropy==$ASTROPY_OPTION
             if [[ -f $PIN_FILE ]]; then
                 awk '{if ($1 != "astropy") print $0}' $PIN_FILE > /tmp/pin_file_temp
                 mv /tmp/pin_file_temp $PIN_FILE
@@ -301,7 +301,7 @@ if [[ ! -z $SUNPY_VERSION ]]; then
         conda install --no-pin $QUIET python=$PYTHON_VERSION $NUMPY_OPTION sunpy=$SUNPY_OPTION || ( \
             $PIP_FALLBACK && ( \
             echo "Installing sunpy with conda was unsuccessful, using pip instead"
-            $PIP_INSTALL sunpy==$SUNPY_OPTION
+            $PIP_INSTALL --upgrade-strategy only-if-needed sunpy==$SUNPY_OPTION
             if [[ -f $PIN_FILE ]]; then
                 awk '{if ($1 != "sunpy") print $0}' $PIN_FILE > /tmp/pin_file_temp
                 mv /tmp/pin_file_temp $PIN_FILE
@@ -349,7 +349,7 @@ if [[ $SETUP_CMD == *build_sphinx* ]] || [[ $SETUP_CMD == *build_docs* ]]; then
             elif [[ $(echo $PIP_PACKAGE_VERSION | cut -c 1-2) =~ $is_eq_number ]]; then
                 PIP_PACKAGE_VERSION='='${PIP_PACKAGE_VERSION}
             fi
-            $PIP_INSTALL ${package}${PIP_PACKAGE_VERSION}
+            $PIP_INSTALL --upgrade-strategy only-if-needed ${package}${PIP_PACKAGE_VERSION}
             awk -v package=$package '{if ($1 != package) print $0}' /tmp/pin_file_copy > $PIN_FILE
         ))
     done
@@ -379,7 +379,7 @@ if [[ ! -z $CONDA_DEPENDENCIES ]]; then
                 # too.
                 awk -v package=$package '{if ($1 != package) print $0}' /tmp/pin_copy > /tmp/pin_copy_temp
                 mv /tmp/pin_copy_temp /tmp/pin_copy
-                $PIP_INSTALL $package);
+                $PIP_INSTALL --upgrade-strategy only-if-needed $package);
         done
         mv /tmp/pin_copy $PIN_FILE))
 fi


### PR DESCRIPTION
To fix #241. pip should ideally never upgrade dependencies, or at least stick to the version numbers pinned for conda