### PR TITLE
No longer necessary to check for pinned pytest in test

### DIFF
--- a/test_env.py
+++ b/test_env.py
@@ -6,10 +6,6 @@ from distutils.version import LooseVersion
 import pytest
 
 PYTEST_LT_3 = LooseVersion(pytest.__version__) < LooseVersion('3')
-PYTEST_LT_32 = LooseVersion(pytest.__version__) < LooseVersion('3.2')
-
-# Remove this assert once we remove pinning pytest
-assert PYTEST_LT_32
 
 # If we are on Travis or AppVeyor, we should check if we are running the tests
 # in the ci-helpers repository, or whether for example someone else is running


### PR DESCRIPTION
Unless I'm mistaken, since astropy/astropy#6419 has been closed, it is no longer necessary to assert that we're using `pytest<3.2` when testing.