### PR TITLE
Updating conda version to latest version 4.3.27

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ environment variables
   In addition, if ``SETUP_CMD`` contains the following flags, extra dependencies are installed:
 
     * ``--coverage``: the coverage and coveralls packages are installed
-    * ``--cov``: the pytest-cov and coveralls packages is installed
+    * ``--cov``: the pytest-cov and coveralls packages are installed
     * ``--parallel`` or ``--numprocesses``: the pytest-xdist package is installed
     * ``--open-files``: the psutil package is installed
 

--- a/appveyor/install-miniconda.ps1
+++ b/appveyor/install-miniconda.ps1
@@ -39,7 +39,7 @@ $env:LATEST_SUNPY_STABLE = "0.8.1"
 # We pin the version for conda as it's not the most stable package from
 # release to release. Add note here if version is pinned due to a bug upstream.
 if (! $env:CONDA_VERSION) {
-   $env:CONDA_VERSION = "4.3.21"
+   $env:CONDA_VERSION = "4.3.27"
 }
 
 if (! $env:PIP_FALLBACK) {

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -44,7 +44,7 @@ fi
 # We pin the version for conda as it's not the most stable package from
 # release to release. Add note here if version is pinned due to a bug upstream.
 if [[ -z $CONDA_VERSION ]]; then
-    CONDA_VERSION=4.3.21
+    CONDA_VERSION=4.3.27
 fi
 
 PIN_FILE_CONDA=$HOME/miniconda/conda-meta/pinned


### PR DESCRIPTION
We need to update to this version as the infra at the default channel changes with it.

See: https://github.com/conda/conda/issues/6069#issuecomment-333938078

Before merging we need to make sure this will work with at least astropy core and e.g. photutils/astroquery.

https://travis-ci.org/bsipocz/astropy/builds/282870686
https://travis-ci.org/bsipocz/photutils/builds/282871701
https://travis-ci.org/bsipocz/astroquery/builds/282870888