### PR TITLE
Allowing the stylecheckers to run for docs_only builds

### DIFF
--- a/travis/setup_conda.sh
+++ b/travis/setup_conda.sh
@@ -47,7 +47,8 @@ if [[ ! -z $(echo ${COMMIT_MESSAGE} | grep -E "${TR_SKIP}") ]]; then
     echo "Travis was requested to be skipped by the commit message, exiting."
     travis_terminate 0
 elif [[ ! -z $(echo ${COMMIT_MESSAGE} | grep -E "${DOCS_ONLY}") ]]; then
-    if [[ $SETUP_CMD != *build_docs* ]] && [[ $SETUP_CMD != *build_sphinx* ]]; then
+    if ! [[ $SETUP_CMD =~ build_docs|build_sphinx|pycodestyle|flake|pep8 ]]; then
+        # we also allow the style checkers to run here
         echo "Only docs build was requested by the commit message, exiting."
         travis_terminate 0
     fi


### PR DESCRIPTION
@astrofrog - are you OK with this change? In #245 @MSeifert04 argued that the overhead is not that big from the point the job gets terminated to actually run the style checkers.

Close #245 