### PR TITLE
coveralls should be installed the same way for --cov as for --coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,9 +68,9 @@ environment variables
   In addition, if ``SETUP_CMD`` contains the following flags, extra dependencies are installed:
 
     * ``--coverage``: the coverage and coveralls packages are installed
+    * ``--cov``: the pytest-cov and coveralls packages is installed
     * ``--parallel`` or ``--numprocesses``: the pytest-xdist package is installed
     * ``--open-files``: the psutil package is installed
-    * ``--cov``: the pytest-cov package is installed
 
 * ``$NUMPY_VERSION``: if set to ``dev`` or ``development``, the latest
   developer version of Numpy is installed along with Cython. If set to a

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -492,6 +492,7 @@ fi
 
 if [[ $SETUP_CMD == *--cov* ]]; then
     $CONDA_INSTALL pytest-cov
+    $PIP_INSTALL coveralls
 fi
 
 


### PR DESCRIPTION
To get a bit of self consistency.

@kain88-de - Does it look OK to you? (asking as you were added the ``--cov`` trigger for the pytest-cov install)