### PR TITLE
Terminate astropy lts==stable cases early

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,10 @@ environment variables
   version of Astropy. If set to ``prerelease``, the pre-release version of
   Astropy gets installed if there is any, otherwise the build exits and
   passes on Travis without running the tests. If set to ``lts`` the latest
-  long term support (LTS) version is installed (more info about LTS can be
-  found
+  long term support (LTS) version is installed. If the ``stable`` version is
+  also an LTS version, the build exits without running the tests assuming
+  there are other jobs in the Travis matrix that test the ``stable``
+  release. (More info about version numbering, and LTS can be found
   [here](https://github.com/astropy/astropy-APEs/blob/master/APE2.rst#version-numbering).
 
 * ``$SUNPY_VERSION``: if set to ``dev`` or ``development``, the latest

--- a/travis/setup_conda.sh
+++ b/travis/setup_conda.sh
@@ -13,7 +13,6 @@ fi
 
 export LATEST_ASTROPY_STABLE=2.0.3
 export ASTROPY_LTS_VERSION=2.0.3
-export LATEST_NUMPY_STABLE=1.14
 export LATEST_SUNPY_STABLE=0.8.2
 
 # First check: if the build should be run at all based on the event type

--- a/travis/setup_conda.sh
+++ b/travis/setup_conda.sh
@@ -11,6 +11,11 @@ if [[ $DEBUG == True ]]; then
     set -x
 fi
 
+export LATEST_ASTROPY_STABLE=2.0.3
+export ASTROPY_LTS_VERSION=2.0.3
+export LATEST_NUMPY_STABLE=1.14
+export LATEST_SUNPY_STABLE=0.8.2
+
 # First check: if the build should be run at all based on the event type
 
 if [[ ! -z $EVENT_TYPE ]]; then
@@ -50,6 +55,14 @@ elif [[ ! -z $(echo ${COMMIT_MESSAGE} | grep -E "${DOCS_ONLY}") ]]; then
     if ! [[ $SETUP_CMD =~ build_docs|build_sphinx|pycodestyle|flake|pep8 ]]; then
         # we also allow the style checkers to run here
         echo "Only docs build was requested by the commit message, exiting."
+        travis_terminate 0
+    fi
+fi
+
+if [[ $ASTROPY_VERSION == lts ]]; then
+    # We skip the build if the LTS version is the same as latest stable
+    if [[ $LATEST_ASTROPY_STABLE == ${ASTROPY_LTS_VERSION}* ]]; then
+        echo "The latest stable version of astropy is an LTS version, skipping testing as LTS"
         travis_terminate 0
     fi
 fi

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -18,11 +18,6 @@ conda config --set always_yes yes --set changeps1 no
 
 shopt -s nocasematch
 
-export LATEST_ASTROPY_STABLE=2.0.3
-ASTROPY_LTS_VERSION=2.0.3
-LATEST_NUMPY_STABLE=1.14
-LATEST_SUNPY_STABLE=0.8.2
-
 if [[ -z $PIP_FALLBACK ]]; then
     PIP_FALLBACK=true
 fi
@@ -246,12 +241,6 @@ if [[ ! -z $ASTROPY_VERSION ]]; then
     elif [[ $ASTROPY_VERSION == stable ]]; then
         ASTROPY_OPTION=$LATEST_ASTROPY_STABLE
     elif [[ $ASTROPY_VERSION == lts ]]; then
-        # We ship the build if the LTS version is the same as latest stable
-        if [[ $LATEST_ASTROPY_STABLE == ${ASTROPY_LTS_VERSION}* ]]; then
-            echo "The latest stable version of astropy is an LTS version, skipping testing as LTS"
-            travis_terminate 0
-        fi
-
         # We add astropy to the pin file to make sure it won't get updated
         echo "astropy ${ASTROPY_LTS_VERSION}*" >> $PIN_FILE
         ASTROPY_OPTION=$ASTROPY_LTS_VERSION

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -18,6 +18,8 @@ conda config --set always_yes yes --set changeps1 no
 
 shopt -s nocasematch
 
+LATEST_NUMPY_STABLE=1.14
+
 if [[ -z $PIP_FALLBACK ]]; then
     PIP_FALLBACK=true
 fi


### PR DESCRIPTION
No need to do it after the conda env is set up and numpy is installed.

Since the version env variables are also been moved, we shouldn't merge this until auto PRs are opened to each and every repo that uses this to switch to use ``setup_conda.py`` rather than directly the OS specific ones...