### PR TITLE
installing pytest-astropy for astropy 3.0+ testing

### DIFF
--- a/appveyor/install-miniconda.ps1
+++ b/appveyor/install-miniconda.ps1
@@ -271,6 +271,7 @@ if ($env:NUMPY_VERSION -match "dev") {
 # Check whether the developer version of Astropy is required and if yes install
 # it. We need to include --no-deps to make sure that Numpy doesn't get upgraded.
 if ($env:ASTROPY_VERSION -match "dev") {
+   Invoke-Expression "${env:CMD_IN_ENV} pip install pytest-astropy"
    Invoke-Expression "${env:CMD_IN_ENV} pip install git+https://github.com/astropy/astropy.git#egg=astropy --upgrade --no-deps"
    checkLastExitCode
 }

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -419,6 +419,15 @@ fi
 
 if [[ $ASTROPY_VERSION == dev* ]]; then
     $CONDA_INSTALL Cython jinja2
+    # Make sure pytest-astropy is available for astropy 3.0+, including it's
+    # dependencies. However be careful in case the version numbers are
+    # pinned. Ideally we'll have a conda package of pytest-astropy, so won't
+    # need this hack.
+    if [ ! -z $PYTEST_VERSION ]; then
+        $PIP_INSTALL pytest-astropy pytest==PYTEST_VERSION
+    else
+        $PIP_INSTALL pytest-astropy
+    fi
     $PIP_INSTALL git+https://github.com/astropy/astropy.git#egg=astropy --upgrade --no-deps
 fi
 


### PR DESCRIPTION
currently that is only astropy dev, the case for stable will also needs the update once 3.0 is out. 

Given that ``pytest-astropy`` is a pseudo package, we can't pip install it with ``--no-deps``, so we absolutely need to make sure it doesn't bring in any upgrade to dependencies already installed with conda, or where we fixed the version number previously. One way around this problem can be to start packaging it for conda.