### PR TITLE
remove else clause of resolved PR 6419

### DIFF
--- a/test_env.py
+++ b/test_env.py
@@ -6,10 +6,7 @@ from distutils.version import LooseVersion
 import pytest
 
 PYTEST_LT_3 = LooseVersion(pytest.__version__) < LooseVersion('3')
-PYTEST_LT_32 = LooseVersion(pytest.__version__) < LooseVersion('3.2')
 
-# Remove this assert once we remove pinning pytest
-assert PYTEST_LT_32
 
 # If we are on Travis or AppVeyor, we should check if we are running the tests
 # in the ci-helpers repository, or whether for example someone else is running

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -96,10 +96,6 @@ fi
 
 if [[ ! -z $PYTEST_VERSION ]]; then
     echo "pytest ${PYTEST_VERSION}*" >> $PIN_FILE
-else
-    # Remove this else clause when
-    # https://github.com/astropy/astropy/pull/6419 is solved
-    echo "pytest <3.2" >> $PIN_FILE
 fi
 
 if [[ ! -z $PIP_VERSION ]]; then

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -82,6 +82,8 @@ source activate test
 
 # PIN FILE
 PIN_FILE=$HOME/miniconda/envs/test/conda-meta/pinned
+# ensure the PIN_FILE exists
+touch $PIN_FILE
 
 if [[ $DEBUG == True ]]; then
     conda config --show


### PR DESCRIPTION
https://github.com/astropy/astropy/pull/6419 has been resolved and there is a mark that the else should be removed again.

I saw that when I now noticed that ci-helper don't install the latest version of pytest.