### PR TITLE
Uninstall hypothesis 

### DIFF
--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -271,13 +271,6 @@ if [[ ! -z $ASTROPY_VERSION ]]; then
             fi))
     fi
 
-    # Force uninstall hypothesis if it's silently installed as an upstream
-    # dependency as the astropy <2.0.3 machinery is incompatible with
-    # it. But we do that here so that it will be reinstalled if it's an
-    # explicit dependency in PIP_DEPENDENCIES or CONDA_DEPENDENCIES below
-    # https://github.com/astropy/astropy/issues/6919
-    conda remove --force hypothesis || true
-
 fi
 
 # SUNPY
@@ -527,6 +520,27 @@ if [[ $DEBUG == True ]]; then
     # include debug information about the current conda install
     conda install -n root _license
     conda info -a
+fi
+
+if [[ ! -z $ASTROPY_VERSION ]]; then
+    # Force uninstall hypothesis if it's silently installed as an upstream
+    # dependency as the astropy <2.0.3 machinery is incompatible with
+    # it. But if it's an explicit dependency in PIP_DEPENDENCIES or
+    # CONDA_DEPENDENCIES then we only issue a warning.
+    # https://github.com/astropy/astropy/issues/6919
+
+    old_astropy=$(python -c "from distutils.version import LooseVersion;\
+                  import astropy; \
+                  print(LooseVersion(astropy.__version__) <\
+                  LooseVersion('2.0.3'))")
+    if [[ $(echo $CONDA_DEPENDENCIES $PIP_DEPENDENCIES | grep hypothesis) ]]; then
+        no_explicit_dependency=false
+        echo "WARNING: the package 'hypothesis' is incompatible with the Astropy testing mechanism prior version v2.0.3, expect issues during doctesting."
+    fi
+
+    if [[ $old_astropy == True ]] && $no_explicit_dependency; then
+        conda remove --force hypothesis || true
+    fi
 fi
 
 set +x

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -230,6 +230,13 @@ fi
 
 # ASTROPY
 if [[ ! -z $ASTROPY_VERSION ]]; then
+    # force uninstall hypothesis if it's silentry installed as an upstream
+    # dependency as the astropy <2.0.3 machinery is incompatible with
+    # it. But keep it if it's installed as an explicit dependency in
+    # PIP_DEPENDENCIES or CONDA_DEPENDENCIES below
+    # https://github.com/astropy/astropy/issues/6919
+    conda remove --force hypothesis
+
     if [[ $ASTROPY_VERSION == dev* ]]; then
         : # Install at the bottom of this script
     elif [[ $ASTROPY_VERSION == pre* ]]; then

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -230,13 +230,6 @@ fi
 
 # ASTROPY
 if [[ ! -z $ASTROPY_VERSION ]]; then
-    # force uninstall hypothesis if it's silentry installed as an upstream
-    # dependency as the astropy <2.0.3 machinery is incompatible with
-    # it. But keep it if it's installed as an explicit dependency in
-    # PIP_DEPENDENCIES or CONDA_DEPENDENCIES below
-    # https://github.com/astropy/astropy/issues/6919
-    conda remove --force hypothesis || true
-
     if [[ $ASTROPY_VERSION == dev* ]]; then
         : # Install at the bottom of this script
     elif [[ $ASTROPY_VERSION == pre* ]]; then
@@ -277,6 +270,13 @@ if [[ ! -z $ASTROPY_VERSION ]]; then
                 mv /tmp/pin_file_temp $PIN_FILE
             fi))
     fi
+
+    # Force uninstall hypothesis if it's silently installed as an upstream
+    # dependency as the astropy <2.0.3 machinery is incompatible with
+    # it. But we do that here so that it will be reinstalled if it's an
+    # explicit dependency in PIP_DEPENDENCIES or CONDA_DEPENDENCIES below
+    # https://github.com/astropy/astropy/issues/6919
+    conda remove --force hypothesis || true
 
 fi
 

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -235,7 +235,7 @@ if [[ ! -z $ASTROPY_VERSION ]]; then
     # it. But keep it if it's installed as an explicit dependency in
     # PIP_DEPENDENCIES or CONDA_DEPENDENCIES below
     # https://github.com/astropy/astropy/issues/6919
-    conda remove --force hypothesis
+    conda remove --force hypothesis || true
 
     if [[ $ASTROPY_VERSION == dev* ]]; then
         : # Install at the bottom of this script


### PR DESCRIPTION
as a workaround while astropy stable is <2.0.3

(an alternative would be to revert the revert of pinning pytest to <3.2, #257, this may be better as affects only the packages that rely on the astropy testing framework)