### PR TITLE
Updating pinned conda version to the latest 4.3.34

### DIFF
--- a/appveyor/install-miniconda.ps1
+++ b/appveyor/install-miniconda.ps1
@@ -46,7 +46,7 @@ $env:LATEST_SUNPY_STABLE = "0.8.3"
 # We pin the version for conda as it's not the most stable package from
 # release to release. Add note here if version is pinned due to a bug upstream.
 if (! $env:CONDA_VERSION) {
-   $env:CONDA_VERSION = "4.3.27"
+   $env:CONDA_VERSION = "4.3.34"
 }
 
 if (! $env:PIP_FALLBACK) {

--- a/appveyor/install-miniconda.ps1
+++ b/appveyor/install-miniconda.ps1
@@ -41,7 +41,7 @@ else {
 
 $env:ASTROPY_LTS_VERSION = "2.0.4"
 $env:LATEST_NUMPY_STABLE = "1.14"
-$env:LATEST_SUNPY_STABLE = "0.8.3"
+$env:LATEST_SUNPY_STABLE = "0.8.4"
 
 # We pin the version for conda as it's not the most stable package from
 # release to release. Add note here if version is pinned due to a bug upstream.

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -340,12 +340,15 @@ if [[ $SETUP_CMD == *build_sphinx* ]] || [[ $SETUP_CMD == *build_docs* ]]; then
         fi
     fi
 
-    # We don't want to install everything listed in the PIN_FILE in this section
-
+    # We don't want to install everything listed in the PIN_FILE in this
+    # section, but respect the pinned version of packages that are already
+    # installed
+    conda list > /tmp/installed
     for package in matplotlib sphinx; do
         mv $PIN_FILE /tmp/pin_file_copy
 
         awk -v package=$package '{if ($1 == package) print $0}' /tmp/pin_file_copy > $PIN_FILE
+        awk 'FNR==NR{a[$1]=$1;next} $1 in a{print $0}' /tmp/installed /tmp/pin_file_copy >> $PIN_FILE
 
         $CONDA_INSTALL $package && mv /tmp/pin_file_copy $PIN_FILE || ( \
             $PIP_FALLBACK && (\

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -54,7 +54,7 @@ fi
 # We pin the version for conda as it's not the most stable package from
 # release to release. Add note here if version is pinned due to a bug upstream.
 if [[ -z $CONDA_VERSION ]]; then
-    CONDA_VERSION=4.3.27
+    CONDA_VERSION=4.3.34
 fi
 
 PIN_FILE_CONDA=$HOME/miniconda/conda-meta/pinned

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -251,6 +251,9 @@ if [[ ! -z $ASTROPY_VERSION ]]; then
         fi
     elif [[ $ASTROPY_VERSION == stable ]]; then
         ASTROPY_OPTION=$LATEST_ASTROPY_STABLE
+
+        # We add astropy to the pin file to make sure it won't get downgraded
+        echo "astropy ${LATEST_ASTROPY_STABLE}*" >> $PIN_FILE
     elif [[ $ASTROPY_VERSION == lts ]]; then
         # We ship the build if the LTS version is the same as latest stable
         if [[ $LATEST_ASTROPY_STABLE == ${ASTROPY_LTS_VERSION}* ]]; then


### PR DESCRIPTION
We need to update to this version as some stsci packages have some weird conda issues that are solved with conda 4.3.31+

Before merging we need to make sure this will work with at least astropy core and e.g. photutils/astroquery.

https://travis-ci.org/bsipocz/astropy/builds/342439970
https://travis-ci.org/bsipocz/photutils/builds/342441453
