### PR TITLE
Conda install pytest-astropy for stable and dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -97,12 +97,10 @@ matrix:
           env: SUNPY_VERSION=prerelease CONDA_CHANNELS='conda-forge'
 
         # -> Setting pytest version should be recognized in the next two jobs
-        # -> astropy stable should stay on the 2.0.x branch
         - os: linux
           env: SETUP_CMD='build_sphinx' CONDA_DEPENDENCIES='matplotlib<=1.5.0'
                DEBUG=True PYTHON_VERSION=2.7 PYTEST_VERSION=2.7.3
-               ASTROPY_VERSION=stable
-               TEST_CMD='python -c "import matplotlib; assert matplotlib.__version__==\"1.5.0\"; import pytest; assert pytest.__version__.startswith(\"2.7.3\"); import astropy; assert astropy.__version__.startswith(\"2.0\")"'
+               TEST_CMD='python -c "import matplotlib; assert matplotlib.__version__==\"1.5.0\"; import pytest; assert pytest.__version__.startswith(\"2.7.3\")"'
 
         - os: linux
           env: SETUP_CMD='build_sphinx' SPHINX_VERSION=1.4.1 DEBUG=True
@@ -114,8 +112,9 @@ matrix:
                MATPLOTLIB_VERSION=1.5.1 DEBUG=True PYTHON_VERSION=3.5
                TEST_CMD='python -c "import matplotlib; assert matplotlib.__version__=="\""1.5.1"\"'
 
+        # -> astropy stable should stay on the 2.0.x branch
         - os: linux
-          env: SETUP_CMD='build_docs' PYTHON_VERSION=2.7
+          env: SETUP_CMD='build_docs' PYTHON_VERSION=2.7 ASTROPY_VERSION='stable'
 
         - os: linux
           env: MAIN_CMD='pep8'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,6 +33,7 @@ environment:
         PIP_DEPENDENCIES: "astrodendro"
         CONDA_CHANNEL_PRIORITY: "False"
         SUNPY_VERSION: "dev"
+        DEBUG: "True"
 
       - PYTHON_VERSION: "2.7"
         DEBUG: "True"
@@ -86,4 +87,3 @@ build: false
 
 test_script:
   - "%CMD_IN_ENV% %TEST_CMD%"
-

--- a/appveyor/install-miniconda.ps1
+++ b/appveyor/install-miniconda.ps1
@@ -207,11 +207,11 @@ if ($env:ASTROPY_VERSION) {
     } else {
         $ASTROPY_OPTION = "astropy=" + $env:ASTROPY_VERSION
     }
-    $output = cmd /c conda install -n test $QUIET $NUMPY_OPTION $ASTROPY_OPTION 2>&1
+    $output = cmd /c conda install -n test $QUIET $NUMPY_OPTION $ASTROPY_OPTION.Split(" ") 2>&1
     echo $output
     if (($output | select-string UnsatisfiableError) -and $env:PIP_FALLBACK) {
        echo "Installing astropy with conda was unsuccessful, using pip instead"
-       pip install $ASTROPY_OPTION
+       pip install $ASTROPY_OPTION.Split(" ")
        checkLastExitCode
     } else {
       checkLastExitCode

--- a/appveyor/install-miniconda.ps1
+++ b/appveyor/install-miniconda.ps1
@@ -199,9 +199,9 @@ if ($env:NUMPY_VERSION) {
 # Check whether a specific version of Astropy is required
 if ($env:ASTROPY_VERSION) {
     if($env:ASTROPY_VERSION -match "stable") {
-        $ASTROPY_OPTION = "astropy=" + $env:LATEST_ASTROPY_STABLE
+        $ASTROPY_OPTION = "astropy=" + $env:LATEST_ASTROPY_STABLE + " pytest-astropy"
     } elseif($env:ASTROPY_VERSION -match "dev") {
-        $ASTROPY_OPTION = "Cython pip jinja2".Split(" ")
+        $ASTROPY_OPTION = "Cython pip jinja2 pytest-astropy".Split(" ")
     } elseif($env:ASTROPY_VERSION -match "lts") {
         $ASTROPY_OPTION = "astropy=" + $env:ASTROPY_LTS_VERSION
     } else {
@@ -277,7 +277,6 @@ if ($env:NUMPY_VERSION -match "dev") {
 # Check whether the developer version of Astropy is required and if yes install
 # it. We need to include --no-deps to make sure that Numpy doesn't get upgraded.
 if ($env:ASTROPY_VERSION -match "dev") {
-   Invoke-Expression "${env:CMD_IN_ENV} pip install pytest-astropy"
    Invoke-Expression "${env:CMD_IN_ENV} pip install git+https://github.com/astropy/astropy.git#egg=astropy --upgrade --no-deps"
    checkLastExitCode
 }

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -250,10 +250,10 @@ if [[ ! -z $ASTROPY_VERSION ]]; then
             travis_terminate 0
         fi
     elif [[ $ASTROPY_VERSION == stable ]]; then
-        ASTROPY_OPTION=$LATEST_ASTROPY_STABLE
-
         # We add astropy to the pin file to make sure it won't get downgraded
         echo "astropy ${LATEST_ASTROPY_STABLE}*" >> $PIN_FILE
+        ASTROPY_OPTION="$LATEST_ASTROPY_STABLE pytest-astropy"
+
     elif [[ $ASTROPY_VERSION == lts ]]; then
         # We ship the build if the LTS version is the same as latest stable
         if [[ $LATEST_ASTROPY_STABLE == ${ASTROPY_LTS_VERSION}* ]]; then
@@ -428,16 +428,8 @@ fi
 # sure that Numpy doesn't get upgraded.
 
 if [[ $ASTROPY_VERSION == dev* ]]; then
-    $CONDA_INSTALL Cython jinja2
-    # Make sure pytest-astropy is available for astropy 3.0+, including it's
-    # dependencies. However be careful in case the version numbers are
-    # pinned. Ideally we'll have a conda package of pytest-astropy, so won't
-    # need this hack.
-    if [ ! -z $PYTEST_VERSION ]; then
-        $PIP_INSTALL pytest-astropy pytest==PYTEST_VERSION
-    else
-        $PIP_INSTALL pytest-astropy
-    fi
+    $CONDA_INSTALL Cython jinja2 pytest-astropy
+
     $PIP_INSTALL git+https://github.com/astropy/astropy.git#egg=astropy --upgrade --no-deps
 fi
 
@@ -480,7 +472,7 @@ if [[ $ASTROPY_VERSION == stable ]]; then
         # by pip will be used. We use --force to make sure things that depend
         # on astropy don't cause issues or get uninstalled.
         conda remove astropy --force
-        $PIP_INSTALL --upgrade --no-deps --ignore-installed astropy==$LATEST_ASTROPY_STABLE
+        $PIP_INSTALL --upgrade --no-deps --ignore-installed astropy==$LATEST_ASTROPY_STABLE pytest-astropy
     fi
 fi
 

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -267,7 +267,11 @@ if [[ ! -z $ASTROPY_VERSION ]]; then
     else
         # We add astropy to the pin file to make sure it won't get updated
         echo "astropy ${ASTROPY_VERSION}*" >> $PIN_FILE
-        ASTROPY_OPTION=$ASTROPY_VERSION
+        if [[ $(echo ${ASTROPY_VERSION} | cut -b 1) -ge 3 ]]; then
+            ASTROPY_OPTION="$ASTROPY_VERSION pytest-astropy"
+        else
+            ASTROPY_OPTION=$ASTROPY_VERSION
+        fi
     fi
     if [[ ! -z $ASTROPY_OPTION ]]; then
         conda install --no-pin $QUIET python=$PYTHON_VERSION $NUMPY_OPTION astropy=$ASTROPY_OPTION || ( \


### PR DESCRIPTION
This is to close #254 

~Currently includes #273, too, needs to be rebased once that PR is merged.~ The conda update PRs stay separate as they are not as critical as this one.