### PR TITLE
Do not install pytest-astropy for the astropy 2.0.x series

### DIFF
--- a/appveyor/install-miniconda.ps1
+++ b/appveyor/install-miniconda.ps1
@@ -200,7 +200,7 @@ if ($env:NUMPY_VERSION) {
 # Check whether a specific version of Astropy is required
 if ($env:ASTROPY_VERSION) {
     if($env:ASTROPY_VERSION -match "stable") {
-        if($env:NO_PYTEST_ASTROPY -match "True) {
+        if($env:NO_PYTEST_ASTROPY -match "True") {
             $ASTROPY_OPTION = "astropy=" + $env:LATEST_ASTROPY_STABLE
         } else {
             $ASTROPY_OPTION = "astropy=" + $env:LATEST_ASTROPY_STABLE + " pytest-astropy"

--- a/appveyor/install-miniconda.ps1
+++ b/appveyor/install-miniconda.ps1
@@ -37,6 +37,7 @@ if ((python -c "from distutils.version import LooseVersion; import os; print(Loo
 }
 else {
     $env:LATEST_ASTROPY_STABLE = "2.0.4"
+    $env:NO_PYTEST_ASTROPY = "True"
 }
 
 $env:ASTROPY_LTS_VERSION = "2.0.4"
@@ -199,7 +200,11 @@ if ($env:NUMPY_VERSION) {
 # Check whether a specific version of Astropy is required
 if ($env:ASTROPY_VERSION) {
     if($env:ASTROPY_VERSION -match "stable") {
-        $ASTROPY_OPTION = "astropy=" + $env:LATEST_ASTROPY_STABLE + " pytest-astropy"
+        if($env:NO_PYTEST_ASTROPY -match "True) {
+            $ASTROPY_OPTION = "astropy=" + $env:LATEST_ASTROPY_STABLE
+        } else {
+            $ASTROPY_OPTION = "astropy=" + $env:LATEST_ASTROPY_STABLE + " pytest-astropy"
+        }
     } elseif($env:ASTROPY_VERSION -match "dev") {
         $ASTROPY_OPTION = "Cython pip jinja2 pytest-astropy".Split(" ")
     } elseif($env:ASTROPY_VERSION -match "lts") {

--- a/test_env.py
+++ b/test_env.py
@@ -104,6 +104,12 @@ def test_astropy():
                 assert astropy.__version__.startswith(os_astropy_version)
             assert 'dev' not in astropy.__version__
 
+    # We should not install pytest-astropy for the 2.0.x series, since
+    # pytest-astropy is a metapackage, check one of its components
+    if LATEST_ASTROPY_STABLE.startswith('2'):
+        with pytest.raises(ImportError):
+            import pytest_doctestplus
+
 
 def test_sunpy():
     if 'SUNPY_VERSION' in os.environ:

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -28,6 +28,7 @@ if [[ $(python -c "from distutils.version import LooseVersion; import os;\
     export LATEST_ASTROPY_STABLE=3.0
 else
     export LATEST_ASTROPY_STABLE=2.0.4
+    export NO_PYTEST_ASTROPY=True
 fi
 ASTROPY_LTS_VERSION=2.0.4
 LATEST_NUMPY_STABLE=1.14
@@ -252,7 +253,12 @@ if [[ ! -z $ASTROPY_VERSION ]]; then
     elif [[ $ASTROPY_VERSION == stable ]]; then
         # We add astropy to the pin file to make sure it won't get downgraded
         echo "astropy ${LATEST_ASTROPY_STABLE}*" >> $PIN_FILE
-        ASTROPY_OPTION="$LATEST_ASTROPY_STABLE pytest-astropy"
+
+        if [[ $NO_PYTEST_ASTROPY == True ]]; then
+            ASTROPY_OPTION="$LATEST_ASTROPY_STABLE"
+        else
+            ASTROPY_OPTION="$LATEST_ASTROPY_STABLE pytest-astropy"
+        fi
 
     elif [[ $ASTROPY_VERSION == lts ]]; then
         # We ship the build if the LTS version is the same as latest stable


### PR DESCRIPTION
This should fix the python3.4 failures we see with the recent astropy-helpers update PRs.