### PR TITLE
Pin sip when matplotlib is a dependency

### DIFF
--- a/appveyor/install-miniconda.ps1
+++ b/appveyor/install-miniconda.ps1
@@ -249,6 +249,9 @@ if ($env:SUNPY_VERSION) {
 
 # Install the specified versions of numpy and other dependencies
 if ($env:CONDA_DEPENDENCIES) {
+   if ($env:CONDA_DEPENDENCIES -match "matplotlib") {
+   $CONDA_DEPENDENCIES = $env:CONDA_DEPENDENCIES + " sip=4.18"
+   }
     $CONDA_DEPENDENCIES = $env:CONDA_DEPENDENCIES.split(" ")
 } else {
     $CONDA_DEPENDENCIES = ""

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -160,6 +160,15 @@ fi
 # Pin required versions for dependencies, howto is in FAQ of conda
 # http://conda.pydata.org/docs/faq.html#pinning-packages
 if [[ ! -z $CONDA_DEPENDENCIES ]]; then
+
+    # On the defaults conda channel mpl currently segfault with newer sip
+    # versions. While it doesn't happen for all python version, there are
+    # many packages running into the issue, so we better have a temporarily
+    # limitation for everything here.
+    if [[ ! -z $(echo $CONDA_DEPENDENCIES | grep matplotlib) ]]; then
+        CONDA_DEPENDENCIES=${CONDA_DEPENDENCIES}" sip<4.19"
+    fi
+
     echo $CONDA_DEPENDENCIES | awk '{print tolower($0)}' | tr " " "\n" | \
         sed -E -e 's|([a-z0-9]+)([=><!])|\1 \2|g' -e 's| =([0-9])| ==\1|g' >> $PIN_FILE
 


### PR DESCRIPTION
This is still an ugly workaround, but will do the job for now. Should be removed once maplotlib stops segfaulting when installed from the default channel