### PR TITLE
Simplify code when PIP_FALLBACK is False

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -64,6 +64,7 @@ environment:
         ASTROPY_VERSION: "3.0"
         SUNPY_VERSION: "0.9"
         PIP_FALLBACK: "False"
+        CONDA_CHANNELS: "conda-forge"
 
 matrix:
    fast_finish: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -60,6 +60,11 @@ environment:
         CONDA_ENVIRONMENT: "conda_environment.yml"
         TEST_CMD: "python -c \"import matplotlib\""
 
+      - PYTHON_VERSION: "3.6"
+        ASTROPY_VERSION: "3.0"
+        SUNPY_VERSION: "0.9"
+        PIP_FALLBACK: "False"
+
 matrix:
    fast_finish: true
 

--- a/appveyor/install-miniconda.ps1
+++ b/appveyor/install-miniconda.ps1
@@ -217,7 +217,7 @@ if ($env:ASTROPY_VERSION) {
     } else {
         $ASTROPY_OPTION = "astropy=" + $env:ASTROPY_VERSION
     }
-    if ($env:PIP_FALLBACK) {
+    if ($env:PIP_FALLBACK -match "True") {
       $output = cmd /c conda install -n test $QUIET $NUMPY_OPTION $ASTROPY_OPTION.Split(" ") 2>&1
       echo $output
       if ($output | select-string UnsatisfiableError) {
@@ -245,7 +245,7 @@ if ($env:SUNPY_VERSION) {
     } else {
         $SUNPY_OPTION = "sunpy=" + $env:SUNPY_VERSION
     }
-    if ($env:PIP_FALLBACK) {
+    if ($env:PIP_FALLBACK -match "True") {
       $output = cmd /c conda install -n test $QUIET $NUMPY_OPTION $SUNPY_OPTION 2>&1
       echo $output
       if ($output | select-string UnsatisfiableError) {
@@ -276,7 +276,7 @@ if ($env:CONDA_DEPENDENCIES) {
 # If NUMPY_OPTION and CONDA_DEPENDENCIES are both empty, we skip this step
 if ($NUMPY_OPTION -or $CONDA_DEPENDENCIES) {
 
-  if ($env:PIP_FALLBACK) {
+  if ($env:PIP_FALLBACK -match "True") {
     $output = cmd /c conda install -n test $QUIET $NUMPY_OPTION $CONDA_DEPENDENCIES 2>&1
     echo $output
     if ($output | select-string UnsatisfiableError, PackageNotFoundError) {

--- a/appveyor/install-miniconda.ps1
+++ b/appveyor/install-miniconda.ps1
@@ -217,15 +217,21 @@ if ($env:ASTROPY_VERSION) {
     } else {
         $ASTROPY_OPTION = "astropy=" + $env:ASTROPY_VERSION
     }
-    $output = cmd /c conda install -n test $QUIET $NUMPY_OPTION $ASTROPY_OPTION.Split(" ") 2>&1
-    echo $output
-    if (($output | select-string UnsatisfiableError) -and $env:PIP_FALLBACK) {
-       echo "Installing astropy with conda was unsuccessful, using pip instead"
-       pip install $ASTROPY_OPTION.Split(" ")
-       checkLastExitCode
+    if ($env:PIP_FALLBACK) {
+      $output = cmd /c conda install -n test $QUIET $NUMPY_OPTION $ASTROPY_OPTION.Split(" ") 2>&1
+      echo $output
+      if ($output | select-string UnsatisfiableError) {
+         echo "Installing astropy with conda was unsuccessful, using pip instead"
+         pip install $ASTROPY_OPTION.Split(" ")
+         checkLastExitCode
+      } else {
+        checkLastExitCode
+      }
     } else {
+      conda install -n test $QUIET $NUMPY_OPTION $ASTROPY_OPTION.Split(" ")
       checkLastExitCode
     }
+
 } else {
     $ASTROPY_OPTION = ""
 }
@@ -239,13 +245,18 @@ if ($env:SUNPY_VERSION) {
     } else {
         $SUNPY_OPTION = "sunpy=" + $env:SUNPY_VERSION
     }
-    $output = cmd /c conda install -n test $QUIET $NUMPY_OPTION $SUNPY_OPTION 2>&1
-    echo $output
-    if (($output | select-string UnsatisfiableError) -and $env:PIP_FALLBACK) {
-       echo "Installing sunpy with conda was unsuccessful, using pip instead"
-       pip install $SUNPY_OPTION
-       checkLastExitCode
+    if ($env:PIP_FALLBACK) {
+      $output = cmd /c conda install -n test $QUIET $NUMPY_OPTION $SUNPY_OPTION 2>&1
+      echo $output
+      if ($output | select-string UnsatisfiableError) {
+         echo "Installing sunpy with conda was unsuccessful, using pip instead"
+         pip install $SUNPY_OPTION
+         checkLastExitCode
+      } else {
+        checkLastExitCode
+      }
     } else {
+      conda install -n test $QUIET $NUMPY_OPTION $SUNPY_OPTION
       checkLastExitCode
     }
 } else {
@@ -265,17 +276,18 @@ if ($env:CONDA_DEPENDENCIES) {
 # If NUMPY_OPTION and CONDA_DEPENDENCIES are both empty, we skip this step
 if ($NUMPY_OPTION -or $CONDA_DEPENDENCIES) {
 
-  $output = cmd /c conda install -n test $QUIET $NUMPY_OPTION $CONDA_DEPENDENCIES 2>&1
-  echo $output
-  if (($output | select-string UnsatisfiableError, PackageNotFoundError) -and $env:PIP_FALLBACK) {
-     echo "Installing dependencies with conda was unsuccessful, using pip instead"
-     $output = cmd /c pip install $CONDA_DEPENDENCIES 2>&1
-     echo $output
-     checkLastExitCode
-     if ($output | select-string UnsatisfiableError, PackageNotFoundError) {
-        Exit 1
-     }
+  if ($env:PIP_FALLBACK) {
+    $output = cmd /c conda install -n test $QUIET $NUMPY_OPTION $CONDA_DEPENDENCIES 2>&1
+    echo $output
+    if ($output | select-string UnsatisfiableError, PackageNotFoundError) {
+       echo "Installing dependencies with conda was unsuccessful, using pip instead"
+       pip install $CONDA_DEPENDENCIES
+       checkLastExitCode
+    } else {
+      checkLastExitCode
+    }
   } else {
+    conda install -n test $QUIET $NUMPY_OPTION $CONDA_DEPENDENCIES
     checkLastExitCode
   }
 


### PR DESCRIPTION
In cases where PIP_FALLBACK is False, we shouldn't capture the output from the commands (in my case this makes it harder to debug issues). The diff is simpler if you ignore whitespace changes.