### PR TITLE
Don't install any packages with apt on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,13 +8,6 @@ os:
 
 sudo: false
 
-addons:
-    apt:
-        packages:
-            - graphviz
-            - texlive-latex-extra
-            - dvipng
-
 env:
     global:
         - SETUP_CMD='test'


### PR DESCRIPTION
This is an attempt to speed up the build. I don't think we actually need the apt packages?