### PR TITLE
update pinned conda to 4.5.11

### DIFF
--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -55,7 +55,7 @@ fi
 # We pin the version for conda as it's not the most stable package from
 # release to release. Add note here if version is pinned due to a bug upstream.
 if [[ -z $CONDA_VERSION ]]; then
-    CONDA_VERSION=4.3.34
+    CONDA_VERSION=4.5.11
 fi
 
 PIN_FILE_CONDA=$HOME/miniconda/conda-meta/pinned


### PR DESCRIPTION
I *think* this closes #312 .  The one thing I'm not sure about is how much we can trust this won't break *other* dependent projects.  @bsipocz, any thoughts here?