### PR TITLE
pip fallback install to honour non exact version number

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,9 +57,11 @@ matrix:
         # -> Starting with the dev versions as they take the longest to run. We
         #    deliberately test with Numpy 1.13 to check that installing Astropy
         #    dev doesn't upgrade Numpy.
+        # -> testing whether version numbers are respected by pip install fallback
         - os: linux
           env: SETUP_CMD='test' NUMPY_VERSION=1.13 ASTROPY_VERSION=dev
                PYTHON_VERSION=3.5 SUNPY_VERSION=stable CONDA_CHANNELS='conda-forge'
+               SCIKIT_LEARN_VERSION='>=0.20' CONDA_DEPENDENCIES='scikit-learn'
 
         # -> For the Numpy dev build, we also specify a conda package that
         #    depends on Numpy to make sure that Numpy dev is used (because

--- a/test_env.py
+++ b/test_env.py
@@ -163,6 +163,8 @@ def test_dependency_imports():
             __import__('PyQt5')
         elif package == 'scikit-image':
             __import__('skimage')
+        elif package == 'scikit-learn':
+            __import__('sklearn')
         elif package == 'openjpeg':
             continue
         elif package == 'pytest-cov':

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -497,7 +497,11 @@ if [[ $SETUP_CMD == *build_sphinx* ]] || [[ $SETUP_CMD == *build_docs* ]]; then
             echo "Installing $package with conda was unsuccessful, using pip instead."
             PIP_PACKAGE_VERSION=$(awk '{print $2}' $PIN_FILE)
             if [[ $(echo $PIP_PACKAGE_VERSION | cut -c 1) =~ $is_number ]]; then
-                PIP_PACKAGE_VERSION='=='${PIP_${package}_VERSION}
+                if [[ ${PIP_${package}_VERSION} == *">"* || ${PIP_${package}_VERSION} == *"<"* ]]; then
+                   PIP_PACKAGE_VERSION=${PIP_${package}_VERSION}
+                else
+                    PIP_PACKAGE_VERSION='=='${PIP_${package}_VERSION}
+                fi
             elif [[ $(echo $PIP_PACKAGE_VERSION | cut -c 1-2) =~ $is_eq_number ]]; then
                 PIP_PACKAGE_VERSION='='${PIP_PACKAGE_VERSION}
             fi


### PR DESCRIPTION
This is to deal with cases when the version number is defined with a relation rather than equality