### PR TITLE
pip fallback install should really honour non exact version number

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -81,9 +81,9 @@ matrix:
           env: SETUP_CMD='test --coverage' PYTHON_VERSION=3.4
                TEST_CMD='py.test test_env.py && coverage run test_env.py; python -c "import sklearn; assert sklearn.__version__.startswith(\"0.19\")"'
                CONDA_CHANNELS='astropy-ci-extras astrofrog conda-forge'
-               CONDA_DEPENDENCIES='pyqt5 openjpeg photutils pytest pytest-cov'
+               CONDA_DEPENDENCIES='scipy pyqt5 openjpeg photutils pytest pytest-cov scikit-learn'
                DEBUG=True NUMPY_VERSION=1.10 ASTROPY_VERSION=stable
-               SCIKIT_LEARN_VERSION='<0.20,>=0.19' CONDA_DEPENDENCIES='scikit-learn'
+               SCIKIT_LEARN_VERSION='<0.20,>=0.19'
 
         # -> The pre builds should run the testing phase only when a pre
         #    release is available on pypi, otherwise it should pass

--- a/.travis.yml
+++ b/.travis.yml
@@ -83,7 +83,7 @@ matrix:
                CONDA_CHANNELS='astropy-ci-extras astrofrog conda-forge'
                CONDA_DEPENDENCIES='pyqt5 openjpeg photutils pytest pytest-cov'
                DEBUG=True NUMPY_VERSION=1.10 ASTROPY_VERSION=stable
-               SCIKIT_LEARN_VERSION='<=0.20,>=0.19' CONDA_DEPENDENCIES='scikit-learn'
+               SCIKIT_LEARN_VERSION='<0.20,>=0.19' CONDA_DEPENDENCIES='scikit-learn'
 
         # -> The pre builds should run the testing phase only when a pre
         #    release is available on pypi, otherwise it should pass

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,11 +57,9 @@ matrix:
         # -> Starting with the dev versions as they take the longest to run. We
         #    deliberately test with Numpy 1.13 to check that installing Astropy
         #    dev doesn't upgrade Numpy.
-        # -> testing whether version numbers are respected by pip install fallback
         - os: linux
           env: SETUP_CMD='test' NUMPY_VERSION=1.13 ASTROPY_VERSION=dev
                PYTHON_VERSION=3.5 SUNPY_VERSION=stable CONDA_CHANNELS='conda-forge'
-               SCIKIT_LEARN_VERSION='>=0.20' CONDA_DEPENDENCIES='scikit-learn'
 
         # -> For the Numpy dev build, we also specify a conda package that
         #    depends on Numpy to make sure that Numpy dev is used (because
@@ -78,12 +76,14 @@ matrix:
         #    missing from listed channels) to test the install one-by-one.
         # -> Have package dependency that matches partially another package
         #    (pytest vs pytest-cov) when falling back to pip install
+        # -> testing whether version numbers are respected by pip install fallback
         - os: linux
-          env: SETUP_CMD='test --coverage' PYTHON_VERSION=3.5
-               TEST_CMD='py.test test_env.py && coverage run test_env.py'
+          env: SETUP_CMD='test --coverage' PYTHON_VERSION=3.4
+               TEST_CMD='py.test test_env.py && coverage run test_env.py; python -c "import sklearn; assert sklearn.__version__.startswith(\"0.19\")"'
                CONDA_CHANNELS='astropy-ci-extras astrofrog conda-forge'
                CONDA_DEPENDENCIES='pyqt5 openjpeg photutils pytest pytest-cov'
-               DEBUG=True NUMPY_VERSION=1.10 ASTROPY_VERSION=lts
+               DEBUG=True NUMPY_VERSION=1.10 ASTROPY_VERSION=stable
+               SCIKIT_LEARN_VERSION='<=0.20,>=0.19' CONDA_DEPENDENCIES='scikit-learn'
 
         # -> The pre builds should run the testing phase only when a pre
         #    release is available on pypi, otherwise it should pass
@@ -160,7 +160,7 @@ matrix:
 
         # -> Have empty string as dependency list when falling back on pip
         - os: linux
-          env: SETUP_CMD='test' NUMPY_VERSION=stable ASTROPY_VERSION=stable
+          env: SETUP_CMD='test' NUMPY_VERSION=stable ASTROPY_VERSION=lts
                CONDA_DEPENDENCIES=''
 
         - os: linux

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -109,6 +109,11 @@ export ASTROPY_LTS_VERSION=2.0.9
 export LATEST_NUMPY_STABLE=1.15
 export LATEST_SUNPY_STABLE=0.9.2
 
+
+is_number='[0-9]'
+is_eq_number='=[0-9]'
+
+
 if [[ -z $PIP_FALLBACK ]]; then
     PIP_FALLBACK=true
 fi
@@ -443,9 +448,6 @@ if [[ $SETUP_CMD == *build_sphinx* ]] || [[ $SETUP_CMD == *build_docs* ]]; then
     # Check whether there are any version setting env variables, pin them if
     # there are (only need to deal with the case when they aren't listed in
     # CONDA_DEPENDENCIES, otherwise this was already dealt with)
-
-    is_number='[0-9]'
-    is_eq_number='=[0-9]'
 
     if [[ ! -z $MATPLOTLIB_VERSION ]]; then
         if [[ -z $(grep matplotlib $PIN_FILE) ]]; then


### PR DESCRIPTION
This is a hopefully working approach for #338 that actually isn't working.