### PR TITLE
Make version matching pip compatible

### DIFF
--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -191,11 +191,11 @@ fi
 # CORE DEPENDENCIES
 
 if [[ ! -z $PYTEST_VERSION ]]; then
-    echo "pytest ${PYTEST_VERSION}*" >> $PIN_FILE
+    echo "pytest ${PYTEST_VERSION}.*" >> $PIN_FILE
 fi
 
 if [[ ! -z $PIP_VERSION ]]; then
-    echo "pip ${PIP_VERSION}*" >> $PIN_FILE
+    echo "pip ${PIP_VERSION}.*" >> $PIN_FILE
 fi
 
 # We use the channel astropy-ci-extras to host pytest 2.7.3 that is
@@ -281,7 +281,7 @@ if [[ ! -z $CONDA_DEPENDENCIES ]]; then
             awk '{print toupper($0)"_VERSION"}'))
         if [[ ! -z $version && ($version != dev* && $version != pre*) ]]; then
             awk -v package=$package -v version=$version \
-                '{if ($1 == package) print package" " version"*";
+                '{if ($1 == package) print package" " version".*";
                   else print $0}' \
                 $PIN_FILE > /tmp/pin_file_temp
             mv /tmp/pin_file_temp $PIN_FILE
@@ -290,7 +290,7 @@ if [[ ! -z $CONDA_DEPENDENCIES ]]; then
 
     # Do in the pin file what conda silently does on the command line, to
     # extend the underspecified version numbers with *
-    awk -F == '{if (NF==1) print $0; else print $1, $2"*"}' \
+    awk -F == '{if (NF==1) print $0; else print $1, $2".*"}' \
         $PIN_FILE > /tmp/pin_file_temp
     mv /tmp/pin_file_temp $PIN_FILE
 
@@ -366,7 +366,7 @@ if [[ ! -z $ASTROPY_VERSION ]]; then
         fi
     elif [[ $ASTROPY_VERSION == stable ]]; then
         # We add astropy to the pin file to make sure it won't get downgraded
-        echo "astropy ${LATEST_ASTROPY_STABLE}*" >> $PIN_FILE
+        echo "astropy ${LATEST_ASTROPY_STABLE}.*" >> $PIN_FILE
 
         if [[ $NO_PYTEST_ASTROPY == True ]]; then
             ASTROPY_OPTION="$LATEST_ASTROPY_STABLE"
@@ -376,11 +376,11 @@ if [[ ! -z $ASTROPY_VERSION ]]; then
 
     elif [[ $ASTROPY_VERSION == lts ]]; then
         # We add astropy to the pin file to make sure it won't get updated
-        echo "astropy ${ASTROPY_LTS_VERSION}*" >> $PIN_FILE
+        echo "astropy ${ASTROPY_LTS_VERSION}.*" >> $PIN_FILE
         ASTROPY_OPTION=$ASTROPY_LTS_VERSION
     else
         # We add astropy to the pin file to make sure it won't get updated
-        echo "astropy ${ASTROPY_VERSION}*" >> $PIN_FILE
+        echo "astropy ${ASTROPY_VERSION}.*" >> $PIN_FILE
         if [[ $(echo ${ASTROPY_VERSION} | cut -b 1) -ge 3 ]]; then
             ASTROPY_OPTION="$ASTROPY_VERSION pytest-astropy"
         else
@@ -419,7 +419,7 @@ if [[ ! -z $SUNPY_VERSION ]]; then
         SUNPY_OPTION=$LATEST_SUNPY_STABLE
     else
         # We add sunpy to the pin file to make sure it won't get updated
-        echo "sunpy ${SUNPY_VERSION}*" >> $PIN_FILE
+        echo "sunpy ${SUNPY_VERSION}.*" >> $PIN_FILE
         SUNPY_OPTION=$SUNPY_VERSION
     fi
     if [[ ! -z $SUNPY_OPTION ]]; then
@@ -445,7 +445,7 @@ if [[ $SETUP_CMD == *build_sphinx* ]] || [[ $SETUP_CMD == *build_docs* ]]; then
 
     if [[ ! -z $MATPLOTLIB_VERSION ]]; then
         if [[ -z $(grep matplotlib $PIN_FILE) ]]; then
-            echo "matplotlib ${MATPLOTLIB_VERSION}*" >> $PIN_FILE
+            echo "matplotlib ${MATPLOTLIB_VERSION}.*" >> $PIN_FILE
         fi
     fi
 
@@ -467,7 +467,7 @@ if [[ $SETUP_CMD == *build_sphinx* ]] || [[ $SETUP_CMD == *build_docs* ]]; then
 
     if [[ ! -z $SPHINX_VERSION ]]; then
         if [[ -z $(grep sphinx $PIN_FILE) ]]; then
-            echo "sphinx ${SPHINX_VERSION}*" >> $PIN_FILE
+            echo "sphinx ${SPHINX_VERSION}.*" >> $PIN_FILE
         fi
     fi
 


### PR DESCRIPTION
pip is more strict than conda with version matchings and requires one to say `0.18.*` instead of just `0.18*`