### PR TITLE
Making sure pytest version is correctly handled by pip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,10 +40,12 @@ matrix:
         # -> Test falling back on pip when conda install is not working.
         #    Here healpy is not available with numpy >=1.13
         # -> Test installing dev matplotlib
+        # -> Pytest pip fall back handles version number correctly
         - os: linux
           env: NUMPY_VERSION=stable CONDA_DEPENDENCIES='healpy matplotlib'
                CONDA_CHANNELS='conda-forge' DEBUG=True
                SUNPY_VERSION=dev MATPLOTLIB_VERSION='dev'
+               PYTEST_VERSION="<3.4"
 
         # -> Testing whether pip install fallback is working for sphinx/matplotlib in the docs builds
         # -> Test we have a recent pip version, the newest on the defaults channel

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -207,7 +207,14 @@ retry_on_known_error conda install -c astropy-ci-extras --no-channel-priority $Q
     if [[ ! -z $PYTEST_VERSION ]]; then
         echo "Installing pytest with conda was unsuccessful, using pip instead"
         retry_on_known_error conda install $QUIET $PYTHON_OPTION pip
-        pip install pytest==$PYTEST_VERSION
+        if [[ $(echo $PYTEST_VERSION | cut -c 1) =~ $is_number ]]; then
+            PIP_PYTEST_VERSION='=='${PYTEST_VERSION}
+        elif [[ $(echo $PYTEST_VERSION | cut -c 1-2) =~ $is_eq_number ]]; then
+            PIP_PYTEST_VERSION='='${PYTEST_VERSION}
+        else
+            PIP_PYTEST_VERSION=${PYTEST_VERSION}
+        fi
+        pip install pytest${PIP_PYTEST_VERSION}
         awk '{if ($1 != "pytest") print $0}' $PIN_FILE > /tmp/pin_file_temp
         mv /tmp/pin_file_temp $PIN_FILE
     fi)


### PR DESCRIPTION
apparently all but pytest versions got handled in https://github.com/astropy/ci-helpers/pull/341