### PR TITLE
No longer pin sip

### DIFF
--- a/appveyor/install-miniconda.ps1
+++ b/appveyor/install-miniconda.ps1
@@ -397,9 +397,6 @@ if ($env:SUNPY_VERSION) {
 
 # Install the specified versions of numpy and other dependencies
 if ($env:CONDA_DEPENDENCIES) {
-   if ($env:CONDA_DEPENDENCIES -match "matplotlib") {
-      $env:CONDA_DEPENDENCIES += " sip=4.18"
-   }
     $CONDA_DEPENDENCIES = $env:CONDA_DEPENDENCIES.split(" ")
 } else {
     $CONDA_DEPENDENCIES = ""

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -263,14 +263,6 @@ fi
 # http://conda.pydata.org/docs/faq.html#pinning-packages
 if [[ ! -z $CONDA_DEPENDENCIES ]]; then
 
-    # On the defaults conda channel mpl currently segfault with newer sip
-    # versions. While it doesn't happen for all python version, there are
-    # many packages running into the issue, so we better have a temporarily
-    # limitation for everything here.
-    if [[ ! -z $(echo $CONDA_DEPENDENCIES | grep matplotlib) ]]; then
-        CONDA_DEPENDENCIES=${CONDA_DEPENDENCIES}" sip<4.19"
-    fi
-
     if [[ -z $(echo $CONDA_DEPENDENCIES | grep '\bmkl\b') ]]; then
         CONDA_DEPENDENCIES=${CONDA_DEPENDENCIES}" nomkl"
     fi


### PR DESCRIPTION
This undoes https://github.com/astropy/ci-helpers/pull/299 - I *think* it's safe to do this now as I think conda packages for PyQt5 are now pinned against more specific sip versions. The pinning is actually causing issues with some packages (when trying to install glue and matplotlib for example).

(Note: In future it would be good to keep a note of the full details of the environments that e.g. segfaulted so we can verify that new conda packages are indeed available)