### PR TITLE
Added a new mode of using ci-helpers based on pip install -e .[...]

### DIFF
--- a/travis/setup_conda_linux.sh
+++ b/travis/setup_conda_linux.sh
@@ -11,7 +11,11 @@ bash miniconda.sh -b -p $HOME/miniconda
 export PATH="$HOME/miniconda/bin:$PATH"
 
 # Install common Python dependencies
-source "$( dirname "${BASH_SOURCE[0]}" )"/setup_dependencies_common.sh
+if [[ $USE_PIP_INSTALL == True ]]; then
+    source "$( dirname "${BASH_SOURCE[0]}" )"/setup_dependencies_with_pip.sh;
+else
+    source "$( dirname "${BASH_SOURCE[0]}" )"/setup_dependencies_common.sh;
+fi
 
 if [[ $SETUP_XVFB == True ]]; then
     export DISPLAY=:99.0

--- a/travis/setup_conda_osx.sh
+++ b/travis/setup_conda_osx.sh
@@ -20,4 +20,8 @@ bash miniconda.sh -b -p $HOME/miniconda
 export PATH="$HOME/miniconda/bin:$PATH"
 
 # Install common Python dependencies
-source "$( dirname "${BASH_SOURCE[0]}" )"/setup_dependencies_common.sh
+if [[ $USE_PIP_INSTALL == True ]]; then
+    source "$( dirname "${BASH_SOURCE[0]}" )"/setup_dependencies_with_pip.sh;
+else
+    source "$( dirname "${BASH_SOURCE[0]}" )"/setup_dependencies_common.sh;
+fi

--- a/travis/setup_dependencies_with_pip.sh
+++ b/travis/setup_dependencies_with_pip.sh
@@ -1,0 +1,36 @@
+#!/bin/bash -x
+
+# This is an alternative route, which is triggered by the presence of the
+# USE_PIP_INSTALL environment variable, which should be set to True. In this
+# case, dependencies are installed based on the content of install_requires and
+# extras_requires in setup.py. This route is deliberately minimal, so we should
+# add as few extra features to it as possible.
+
+# The recognized variables here are:
+#
+# $PYTHON_VERSION: used to determine the Python version to set up
+# $CONDA_DEPENDENCIES: added to the conda create command
+# $EXTRAS_INSTALL: included inside [] in the pip install command
+# $PIP_DEPENDENCIES: added to the pip install command
+
+set -e
+
+if [[ -z $PYTHON_VERSION ]]; then
+    export PYTHON_VERSION=$TRAVIS_PYTHON_VERSION
+fi
+
+if [[ ! -z $PYTHON_VERSION ]]; then
+    PYTHON_OPTION="python=$PYTHON_VERSION"
+else
+    PYTHON_OPTION=""
+fi
+
+conda create $QUIET -n test $PYTHON_OPTION $CONDA_DEPENDENCIES
+
+source activate test
+
+if [ -z $EXTRAS_INSTALL ]; then
+    pip install -e . $PIP_DEPENDENCIES;
+else
+    pip install -e .[$EXTRAS_INSTALL] $PIP_DEPENDENCIES;
+fi

--- a/travis/setup_dependencies_with_pip.sh
+++ b/travis/setup_dependencies_with_pip.sh
@@ -25,6 +25,14 @@ else
     PYTHON_OPTION=""
 fi
 
+conda config --set always_yes yes --set changeps1 no
+
+if [[ ! -z $CONDA_CHANNELS ]]; then
+    for channel in $CONDA_CHANNELS; do
+        conda config --add channels $channel
+    done
+fi
+
 conda create $QUIET -n test $PYTHON_OPTION $CONDA_DEPENDENCIES
 
 source activate test


### PR DESCRIPTION
This introduces a new way of using ci-helpers where dependencies are primary installed using the dependencies defined in ``install_requires`` and ``extras_require``. This route is deliberately super minimal, and the only environment variables supported are:

* ``$PYTHON_VERSION``: used to determine the Python version to set up with conda
* ``$CONDA_DEPENDENCIES``: added to the conda create command
* ``$EXTRAS_INSTALL``: string included inside [] in the pip install command
* ``$PIP_DEPENDENCIES``: added to the pip install command

This mode is triggered by setting ``$USE_PIP_INSTALL`` to ``True``

This is still a WIP but I plan to test it out with https://github.com/astropy/astropy/pull/8198

