### PR TITLE
Set Matplotlib backend to Agg to avoid segmentation fault

### DIFF
--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -161,6 +161,10 @@ conda config  --set channel_priority $CONDA_CHANNEL_PRIORITY
 # future changes
 export PYTHONIOENCODING=UTF8
 
+# Use Agg backend of Matplotlib to avoid segmentation fault on some
+# versions of pytest.
+export MPLBACKEND="Agg"
+
 # Making sure we don't upgrade python accidentally
 if [[ ! -z $PYTHON_VERSION ]]; then
     PYTHON_OPTION="python=$PYTHON_VERSION"


### PR DESCRIPTION
Fix #356 . This setting was applied successfully in astropy/astroquery#1300 , so @astrofrog suggested that I move this upstream. cc @bsipocz 