### PR TITLE
Adding MPLBACKEND=Agg as default

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,8 @@ environment variables
 * ``SETUP_XVFB``: if True this makes sure e.g., interactive matplotlib
   backends work by starting up a X virtual framebuffer.
 
+* ``MPLBACKEND``: If not specified it is set to ``Agg`` as the default backend.
+
 * ``PACKAGENAME_VERSION``: ``PACKAGENAME`` is the name of the package to
   specify the version for (e.g. ``MATPLOTLIB_VERSION``). Due to shell
   limitations, all hyphens in the conda package name should be changed to

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -168,6 +168,11 @@ else
     PYTHON_OPTION=""
 fi
 
+# Setting the MPL backend to a default to avoid occational segfaults with the qt backend
+if [[ ! -z $MPLBACKEND ]]; then
+    MPLBACKEND=Agg
+fi
+
 # CONDA
 if [[ -z $CONDA_ENVIRONMENT ]]; then
     retry_on_known_error conda create $QUIET -n test $PYTHON_OPTION
@@ -268,7 +273,7 @@ fi
 # http://conda.pydata.org/docs/faq.html#pinning-packages
 if [[ ! -z $CONDA_DEPENDENCIES ]]; then
 
-    if [[ -z $(echo $CONDA_DEPENDENCIES | grep '\bmkl\b') && 
+    if [[ -z $(echo $CONDA_DEPENDENCIES | grep '\bmkl\b') &&
             $TRAVIS_OS_NAME != windows ]]; then
         CONDA_DEPENDENCIES=${CONDA_DEPENDENCIES}" nomkl"
     fi
@@ -316,7 +321,7 @@ fi
 
 
 MKL='nomkl'
-if [[ ! -z $(echo $CONDA_DEPENDENCIES | grep '\bmkl\b') || 
+if [[ ! -z $(echo $CONDA_DEPENDENCIES | grep '\bmkl\b') ||
         $TRAVIS_OS_NAME == windows ]]; then
     MKL=''
 fi

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -170,7 +170,7 @@ fi
 
 # Setting the MPL backend to a default to avoid occational segfaults with the qt backend
 if [[ ! -z $MPLBACKEND ]]; then
-    MPLBACKEND=Agg
+    export MPLBACKEND=Agg
 fi
 
 # CONDA


### PR DESCRIPTION
We started to see mpl related segfaults all over different packages (at least astroquery and photutils). This should provide a central fix for all those, and if needed the backend can be overwritten in the individual repos.