### PR TITLE
Turn errexit off before exiting commons script

### DIFF
--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -748,4 +748,4 @@ if [[ ! -z $ASTROPY_VERSION ]]; then
     fi
 fi
 
-set +x
+set +ex


### PR DESCRIPTION
Closes #363 

As discussed in the related issue, setting the errexit flag in bash with `set -e` combined with ci-helpers requiring the use of `source` means that this flag is set for the rest of the travis job. In travis this causes undesired results when a user's script fails and ends up exiting the entire travis process. This leads to difficult debugging where travis doesn't even include the output for the failing command (flushed log issues maybe) and the job fails.