### PR TITLE
EXP: Disable SSL verification for Appveyor CI

### DIFF
--- a/appveyor/install-miniconda.ps1
+++ b/appveyor/install-miniconda.ps1
@@ -240,6 +240,9 @@ $env:PATH = "${env:PYTHON};${env:PYTHON}\Scripts;" + $env:PATH
 
 # Conda config
 
+conda config --set ssl_verify no
+checkLastExitCode
+
 conda config --set always_yes true
 checkLastExitCode
 


### PR DESCRIPTION
Attempt to fix #369 . Even if this works, this should be a last resort kinda solution, as warned in https://conda.io/docs/user-guide/configuration/disable-ssl-verification.html . This is one of the things suggested over at conda/conda#6007 , which helped some but not others. 🤷‍♀️ 