### PR TITLE
MNT: Only set CFLAGS if not already set

### DIFF
--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -327,8 +327,11 @@ if [[ ! -z $(echo $CONDA_DEPENDENCIES | grep '\bmkl\b') ||
 fi
 
 if [[ $NUMPY_VERSION == dev* ]]; then
-    # We use C99 to build Numpy
-    export CFLAGS="-std=c99"
+    # We use C99 to build Numpy.
+    # If CFLAGS already defined by calling pkg, it's up to them to set this.
+    if [[ -z $CFLAGS ]]; then
+        export CFLAGS="-std=c99"
+    fi
     # We install nomkl here to make sure that Numpy and Scipy versions
     # installed subsequently don't depend on the MKL. If we don't do this, then
     # we run into issues when we install the developer version of Numpy


### PR DESCRIPTION
Follow up of #368. This only sets `CFLAGS` in a numpy-dev job if it is not already set. Otherwise, it would overwrite calling package's setting. If the calling package sets its own `CFLAGS`, then it is on them to set it properly for a numpy-dev job themselves.

p.s. Please double check the BASH syntax. Thanks!