### PR TITLE
Remove outdated Appveyor OS image directive

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -73,8 +73,6 @@ matrix:
 platform:
     -x64
 
-os: Visual Studio 2015 Update 2
-
 install:
 
     # Install Miniconda


### PR DESCRIPTION
As suggested by https://github.com/astropy/ci-helpers/issues/369#issuecomment-451783968 . Fix #369