### PR TITLE
Install codecov in addition to coveralls

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ environment variables
   In addition, if ``SETUP_CMD`` contains the following flags, extra dependencies
   are installed:
 
-    * ``--coverage``: the coverage and coveralls packages are installed
-    * ``--cov``: the pytest-cov and coveralls packages are installed
+    * ``--coverage``: the coverage, coveralls, and codecov packages are installed
+    * ``--cov``: the pytest-cov, coveralls, and codecov packages are installed
     * ``--parallel`` or ``--numprocesses``: the pytest-xdist package is
       installed
     * ``--open-files``: the psutil package is installed

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -704,12 +704,12 @@ fi
 if [[ $SETUP_CMD == *coverage* ]]; then
     # We install requests with conda since it's required by coveralls.
     retry_on_known_error $CONDA_INSTALL coverage requests
-    $PIP_INSTALL coveralls
+    $PIP_INSTALL coveralls codecov
 fi
 
 if [[ $SETUP_CMD == *--cov* ]]; then
     retry_on_known_error $CONDA_INSTALL pytest-cov
-    $PIP_INSTALL coveralls
+    $PIP_INSTALL coveralls codecov
 fi
 
 


### PR DESCRIPTION
Since some packages are now using codecov, it makes sense to provide it here