### PR TITLE
overridable env variable MACOSX_DEPLOYMENT_TARGET=10.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,11 @@ environment variables
 * ``RETRY_DELAY``: a positive integer specifying the number of seconds to wait
   before retrying. If not set, this will default to ``RETRY_DELAY=2``.
 
+* ``MACOSX_DEPLOYMENT_TARGET`` (OSX only): If left blank, the minimum OSX target
+  version for LLVM/Clang builds will be set to ``10.9``.
+  If set to ``"clang_default"``, determining the minimum OSX target version is
+  left to LLVM/Clang. If set to any different value, that value will be used.
+
 The idea behind the ``MAIN_CMD`` and ``SETUP_CMD`` environment variables is
 that the ``script`` section of the ``.travis.yml`` file can be set to:
 

--- a/travis/setup_conda_osx.sh
+++ b/travis/setup_conda_osx.sh
@@ -15,6 +15,16 @@ rvm get stable
 if [[ -z "${MINICONDA_VERSION}" ]]; then
     MINICONDA_VERSION=4.5.12
 fi
+
+# Set default OSX deployment target version to 10.9, since this is required for
+# compiling C++ code with llvm/clang when -stdlib=libc++ is specified.
+# Note that, for linking, version 10.7 should suffice.
+if [[ -z "${MACOSX_DEPLOYMENT_TARGET}" ]]; then
+    export MACOSX_DEPLOYMENT_TARGET=10.9
+elif [[ "${MACOSX_DEPLOYMENT_TARGET}" == "clang_default" ]]; then
+    export MACOSX_DEPLOYMENT_TARGET=""
+fi
+
 wget https://repo.continuum.io/miniconda/Miniconda3-${MINICONDA_VERSION}-MacOSX-x86_64.sh -O miniconda.sh
 bash miniconda.sh -b -p $HOME/miniconda
 export PATH="$HOME/miniconda/bin:$PATH"


### PR DESCRIPTION
Set default OSX deployment target version to 10.9 since this is required for compiling C++ code with llvm/clang when `-stdlib=libc++` is specified.

This is accomplished with the environment variable `MACOSX_DEPLOYMENT_TARGET` which is set to `10.9` if previously empty, unset if previously set to `"clang_default"`, or, otherwise, left as is.

See also issue https://github.com/MDAnalysis/mdanalysis/issues/2180
or PR https://github.com/MDAnalysis/mdanalysis/pull/2184