### PR TITLE
Reduce the number of wget log lines

### DIFF
--- a/travis/setup_conda_linux.sh
+++ b/travis/setup_conda_linux.sh
@@ -6,7 +6,7 @@
 if [[ -z "${MINICONDA_VERSION}" ]]; then
     MINICONDA_VERSION=4.5.12
 fi
-wget https://repo.continuum.io/miniconda/Miniconda3-${MINICONDA_VERSION}-Linux-x86_64.sh -O miniconda.sh
+wget https://repo.continuum.io/miniconda/Miniconda3-${MINICONDA_VERSION}-Linux-x86_64.sh -O miniconda.sh --progress=dot:mega
 bash miniconda.sh -b -p $HOME/miniconda
 export PATH="$HOME/miniconda/bin:$PATH"
 


### PR DESCRIPTION
The current wget generates lots of log lines, like:

```
     0K .......... .......... .......... .......... ..........  0% 4.40M 15s
    50K .......... .......... .......... .......... ..........  0% 5.27M 14s
   100K .......... .......... .......... .......... ..........  0% 13.0M 11s
   150K .......... .......... .......... .......... ..........  0% 9.80M 10s
   200K .......... .......... .......... .......... ..........  0% 12.9M 9s
   250K .......... .......... .......... .......... ..........  0% 27.7M 8s
   300K .......... .......... .......... .......... ..........  0% 18.9M 7s
   350K .......... .......... .......... .......... ..........  0% 22.0M 7s
   400K .......... .......... .......... .......... ..........  0% 23.3M 6s
   450K .......... .......... .......... .......... ..........  0% 38.3M 6s
   500K .......... .......... .......... .......... ..........  0% 42.0M 5s
   550K .......... .......... .......... .......... ..........  0% 33.0M 5s
   600K .......... .......... .......... .......... ..........  0% 34.0M 5s
   650K .......... .......... .......... .......... ..........  1% 37.6M 5s
   700K .......... .......... .......... .......... ..........  1%  136M 4s
   750K .......... .......... .......... .......... ..........  1% 34.4M 4s
   800K .......... .......... .......... .......... ..........  1% 48.5M 4s
   850K .......... .......... .......... .......... ..........  1% 44.6M 4s
   900K .......... .......... .......... .......... ..........  1%  199M 4s
   950K .......... .......... .......... .......... ..........  1% 33.5M 4s
  1000K .......... .......... .......... .......... ..........  1%  195M 3s
  1050K .......... .......... .......... .......... ..........  1% 48.4M 3s
```