### PR TITLE
pip fallback if numpy build for specified python version is missing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -190,6 +190,9 @@ matrix:
         - os: linux
           env: SETUP_CMD='test' CONDA_DEPENDENCIES='matplotlib'
                CONDA_DEPENDENCIES_FLAGS='--no-deps'
+               NUMPY_VERSION=stable PYTHON_VERSION=3.5
+               CONDA_CHANNELS='conda-forge'
+               
 
         - os: linux
           env: SETUP_CMD='test' PIP_DEPENDENCIES='pyparsing requests'

--- a/.travis.yml
+++ b/.travis.yml
@@ -190,9 +190,12 @@ matrix:
         - os: linux
           env: SETUP_CMD='test' CONDA_DEPENDENCIES='matplotlib'
                CONDA_DEPENDENCIES_FLAGS='--no-deps'
-               NUMPY_VERSION=stable PYTHON_VERSION=3.5
-               CONDA_CHANNELS='conda-forge'
-               
+               NUMPY_VERSION=1.16 PYTHON_VERSION=3.5
+
+        - os: linux
+          env: SETUP_CMD='test' CONDA_DEPENDENCIES='matplotlib'
+               CONDA_DEPENDENCIES_FLAGS='--no-deps'
+               NUMPY_VERSION=1.16.1 PYTHON_VERSION=3.5
 
         - os: linux
           env: SETUP_CMD='test' PIP_DEPENDENCIES='pyparsing requests'

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -375,8 +375,14 @@ if [[ ! -z $NUMPY_INSTALL ]]; then
         if [[ -z $NUMPY_OPTION ]]; then
             PIP_NUMPY_OPTION="numpy"
         else
+            # add wildcard for float-like version specs:
             if [[ $NUMPY_OPTION =~ ^numpy$is_eq_float$ ]]; then
                 PIP_NUMPY_OPTION="numpy==${NUMPY_OPTION#*=}.*"
+            # use exact version definitions as is:
+            elif [[ $NUMPY_OPTION =~ ^numpy=.* ]]; then
+                PIP_NUMPY_OPTION="numpy==${NUMPY_OPTION#numpy=}"
+            # Should version specs with 'numpy>=X' etc. ever be used,
+            # use these as is:
             else
                 PIP_NUMPY_OPTION="$NUMPY_OPTION"
             fi


### PR DESCRIPTION
### Problem ###
Since #382, builds with `PYTHON_VERSION=3.5` and `NUMPY_VERSION=stable` lead to Python 3.7 being installed because conda-forge doesn't provide a py35 build of numpy 1.16.
This leads either to
* tests with a wrong Python version, or
* build failure if packages without a pip candidate are required.

See also [MDAnalysis Issue #2217](https://github.com/MDAnalysis/mdanalysis/issues/2217).

### Solution ###
* Do not change python version if no matching numpy build available, i.e. add `PYTHON_OPTION` to `conda install` call during numpy installation.
* If installing numpy with conda fails, remove `NUMPY_OPTION` from `CONDA_INSTALL` and add it to `PIP_DEPENDENCIES` instead.

I currently don't have a Windows machine around to tinker with the PS script. So, for now, this PR just fixes the issue for Travis.
