### PR TITLE
ENH: Add option for no pip upgrade

### DIFF
--- a/appveyor/install-miniconda.ps1
+++ b/appveyor/install-miniconda.ps1
@@ -315,8 +315,9 @@ checkLastExitCode
 # which may lead to ignore install dependencies of the package we test.
 # This update should not interfere with the rest of the functionalities
 # here.
-pip install --upgrade pip
-
+if ($env:PIP_NO_UPGRADE -notmatch "True") {
+    pip install --upgrade pip
+}
 # Check whether a specific version of Numpy is required
 if ($env:NUMPY_VERSION) {
     if($env:NUMPY_VERSION -match "stable") {


### PR DESCRIPTION
On latest `master` on Azure (using AppVeyor scripts) in the last day or so I mysteriously [started getting](https://dev.azure.com/mne-tools/mne-python/_build/results?buildId=853):
```
DEBUG:  318+  >>>> pip install --upgrade pip
Collecting pip
  Downloading https://files.pythonhosted.org/packages/f9/fb/863012b13912709c13cf5cfdbfb304fa6c727659d6290438e1a88df9d848/pip-19.1-py2.py3-none-any.whl (1.4MB)
Installing collected packages: pip
  Found existing installation: pip 19.0.3
    Uninstalling pip-19.0.3:
Could not install packages due to an EnvironmentError: [WinError 5] Access is denied: 'd:\\a\\1\\s\\conda\\envs\\test\\scripts\\pip.exe'
Consider using the `--user` option or check the permissions.
```
This PR seems to [fix it for us](https://dev.azure.com/mne-tools/mne-python/_build/results?buildId=858) )(or at least gets us past the conda/ci-helpers stage) when we [use the added PIP_NO_UPGRADE=True](https://github.com/mne-tools/mne-python/pull/6214/files) flag.

Don't know why this just started happening, as ci-helpers didn't seem to change anything. Perhaps Azure updated an image...? In any case, this workaround works. Let me know if the variables make sense or should be otherwise changed.