### PR TITLE
Remove astropy-ci-extras

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,12 +33,6 @@ matrix:
         - os: windows
           env: PYTHON_VERSION=3.7
 
-        # -> even if CHANNEL_PRIORITY is true then the old pytest shouldn't
-        #     be picked up from the astropy-ci-extras channel.
-        - os: linux
-          env: CONDA_PRIORITY=True CONDA_CHANNELS='conda-forge'
-               TEST_CMD='python -c "import pytest; assert int(pytest.__version__[0])>2"'
-
         # -> tests sunpy dev
         # -> Test falling back on pip when conda install is not working.
         #    Here healpy is not available with numpy >=1.13
@@ -89,7 +83,7 @@ matrix:
         - os: linux
           env: SETUP_CMD='test --coverage' PYTHON_VERSION=3.4
                TEST_CMD='py.test test_env.py && coverage run test_env.py; python -c "import sklearn; assert sklearn.__version__.startswith(\"0.19\")"'
-               CONDA_CHANNELS='astropy-ci-extras astrofrog conda-forge'
+               CONDA_CHANNELS='astrofrog conda-forge'
                CONDA_DEPENDENCIES='scipy pyqt5 openjpeg photutils pytest pytest-cov scikit-learn'
                DEBUG=True NUMPY_VERSION=1.10 ASTROPY_VERSION=stable
                SCIKIT_LEARN_VERSION='<0.20,>=0.19'

--- a/README.md
+++ b/README.md
@@ -228,8 +228,6 @@ This does the following:
 - Set up a conda environment named 'test' and switch to it.
 - Set the ``always_yes`` config option for conda to ``true`` so that you don't
   need to include ``--yes``.
-- Register the specified channels, or if not stated the ``astropy``,
-  ``astropy-ci-extras``, and ``openastronomy`` channels.
 
 Following this, various dependencies are installed depending on the following
 environment variables:

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -211,12 +211,7 @@ fi
 
 export PIP_INSTALL='python -m pip install'
 
-# We use the channel astropy-ci-extras to host pytest 2.7.3 that is
-# compatible with LTS 1.0.x astropy. We need to disable channel priority for
-# this step to make sure the latest version is picked up when
-# CHANNEL_PRIORITY is set to True above.
-retry_on_known_error conda install -c astropy-ci-extras --no-channel-priority $QUIET $PYTHON_OPTION pytest pip || ( \
-    $PIP_FALLBACK && ( \
+$PIP_FALLBACK && ( \
     if [[ ! -z $PYTEST_VERSION ]]; then
         echo "Installing pytest with conda was unsuccessful, using pip instead"
         retry_on_known_error conda install $QUIET $PYTHON_OPTION pip
@@ -231,7 +226,7 @@ retry_on_known_error conda install -c astropy-ci-extras --no-channel-priority $Q
         awk '{if ($1 != "pytest") print $0}' $PIN_FILE > /tmp/pin_file_temp
         mv /tmp/pin_file_temp $PIN_FILE
     fi)
-)
+
 
 # In case of older python versions there isn't an up-to-date version of pip
 # which may lead to ignore install dependencies of the package we test.
@@ -688,9 +683,8 @@ fi
 
 # ASTROPY STABLE
 
-# Due to recent instability in conda, and as new releases are not built in
-# astropy-ci-extras, this workaround ensures that we use the latest stable
-# version of astropy.
+# Due to recent instability in conda, this workaround ensures that we use the
+# latest stable version of astropy.
 
 if [[ $ASTROPY_VERSION == stable ]]; then
     old_astropy=$(python -c "from distutils.version import LooseVersion;\

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -211,7 +211,8 @@ fi
 
 export PIP_INSTALL='python -m pip install'
 
-$PIP_FALLBACK && ( \
+retry_on_known_error conda install --no-channel-priority $QUIET $PYTHON_OPTION pytest pip || ( \
+    $PIP_FALLBACK && ( \
     if [[ ! -z $PYTEST_VERSION ]]; then
         echo "Installing pytest with conda was unsuccessful, using pip instead"
         retry_on_known_error conda install $QUIET $PYTHON_OPTION pip
@@ -226,7 +227,7 @@ $PIP_FALLBACK && ( \
         awk '{if ($1 != "pytest") print $0}' $PIN_FILE > /tmp/pin_file_temp
         mv /tmp/pin_file_temp $PIN_FILE
     fi)
-
+)
 
 # In case of older python versions there isn't an up-to-date version of pip
 # which may lead to ignore install dependencies of the package we test.


### PR DESCRIPTION
It hasn't been used for a while and has been archived. We don't really support versions any more that would rely on it.