### PR TITLE
Activate conda on Windows the official™️ way

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ environment:
   global:
       PYTHON: "C:\\conda"
       MINICONDA_VERSION: "latest"
-      CONDA_VERSION: "4.6"
+      CONDA_VERSION: "4.7"
       CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\ci-helpers\\appveyor\\windows_sdk.cmd"
       PYTHON_ARCH: "64" # needs to be set for CMD_IN_ENV to succeed. If a mix
                         # of 32 bit and 64 bit builds are needed, move this

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -78,6 +78,9 @@ install:
     # Install Miniconda
     - "git clone . ci-helpers"
     - "powershell ci-helpers/appveyor/install-miniconda.ps1"
+    # Activate again...maybe necessary because the first activate
+    # was in powershell?
+    -  CALL "%PYTHON%\\Scripts\\activate.bat"
     # From https://github.com/geopandas/geopandas/pull/1029/files#diff-180360612c6b8c4ed830919bbb4dd459R33
     # this is basically equivalent to what conda init does.  It changes the
     # "conda" to be a .bat script that sets appropriate PATH entries before

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,7 @@ environment:
   global:
       PYTHON: "C:\\conda"
       MINICONDA_VERSION: "latest"
+      CONDA_VERSION: "4.7"
       CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\ci-helpers\\appveyor\\windows_sdk.cmd"
       PYTHON_ARCH: "64" # needs to be set for CMD_IN_ENV to succeed. If a mix
                         # of 32 bit and 64 bit builds are needed, move this

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -97,4 +97,5 @@ install:
 build: false
 
 test_script:
+  - "conda info -a"
   - "%CMD_IN_ENV% %TEST_CMD%"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -69,7 +69,7 @@ environment:
         CONDA_CHANNELS: "conda-forge"
 
 matrix:
-   fast_finish: true
+   fast_finish: false
 
 platform:
     -x64

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ environment:
   global:
       PYTHON: "C:\\conda"
       MINICONDA_VERSION: "latest"
-      CONDA_VERSION: "4.7"
+      CONDA_VERSION: "4.6"
       CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\ci-helpers\\appveyor\\windows_sdk.cmd"
       PYTHON_ARCH: "64" # needs to be set for CMD_IN_ENV to succeed. If a mix
                         # of 32 bit and 64 bit builds are needed, move this

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -79,9 +79,7 @@ install:
     - "git clone . ci-helpers"
     - "powershell ci-helpers/appveyor/install-miniconda.ps1"
 
-    # Set path again, need to find a way to avoid doing this again
-    - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
-    - "activate test"
+    - "conda activate test"
 
     # Test that PATH is set correctly
     - "conda --version"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -78,7 +78,11 @@ install:
     # Install Miniconda
     - "git clone . ci-helpers"
     - "powershell ci-helpers/appveyor/install-miniconda.ps1"
-
+    # From https://github.com/geopandas/geopandas/pull/1029/files#diff-180360612c6b8c4ed830919bbb4dd459R33
+    # this is basically equivalent to what conda init does.  It changes the
+    # "conda" to be a .bat script that sets appropriate PATH entries before
+    # conda hits problems.
+    -  set "PATH=%PYTHON%\condabin:%PATH%"
     - "conda activate test"
 
     # Test that PATH is set correctly

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -98,4 +98,5 @@ build: false
 
 test_script:
   - "conda info -a"
+  - conda list
   - "%CMD_IN_ENV% %TEST_CMD%"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,7 +20,7 @@ environment:
 
       - PYTHON_VERSION: "2.7"
         DEBUG: "True"
-        PYTEST_VERSION: "<4"
+        PYTEST_VERSION: "=3"
         TEST_CMD: "python -c \"import pytest; assert int(pytest.__version__[0])<4\""
 
       - PYTHON_VERSION: "3.5"

--- a/appveyor/install-miniconda.ps1
+++ b/appveyor/install-miniconda.ps1
@@ -282,6 +282,9 @@ if (! $env:CONDA_ENVIRONMENT ) {
 }
 checkLastExitCode
 
+conda create $QUIET -n test
+checkLastExitCode
+
 conda activate test
 checkLastExitCode
 

--- a/appveyor/install-miniconda.ps1
+++ b/appveyor/install-miniconda.ps1
@@ -235,8 +235,10 @@ if (! $env:MINICONDA_VERSION) {
 InstallMiniconda $env:MINICONDA_VERSION $env:PLATFORM $env:PYTHON
 checkLastExitCode
 
-# Set environment variables
-$env:PATH = "${env:PYTHON};${env:PYTHON}\Scripts;" + $env:PATH
+# Add conda to path
+& "${env:PYTHON}\Scripts\activate.bat"
+# Equivalent to conda init
+$env:PATH = "${env:PYTHON}\condabin;" + $env:PATH
 
 # Conda config
 
@@ -280,7 +282,7 @@ if (! $env:CONDA_ENVIRONMENT ) {
 }
 checkLastExitCode
 
-activate test
+conda activate test
 checkLastExitCode
 
 # Set environment variables for environment (activate test doesn't seem to do the trick)

--- a/appveyor/install-miniconda.ps1
+++ b/appveyor/install-miniconda.ps1
@@ -260,7 +260,8 @@ if ($env:CONDA_CHANNELS) {
 }
 
 # Install the build and runtime dependencies of the project.
-retry_on_known_error conda install $QUIET conda=$env:CONDA_VERSION
+# Pulled out retry_on_knwon_error for now
+conda install $QUIET conda=$env:CONDA_VERSION
 checkLastExitCode
 
 if (! $env:CONDA_CHANNEL_PRIORITY) {
@@ -314,7 +315,8 @@ if ($env:DEBUG) {
    Get-Content ${env:PYTHON}\envs\test\conda-meta\pinned
 }
 
-retry_on_known_error conda install $QUIET -n test pytest pip
+# Pulled out retry_on_known_error
+conda install $QUIET -n test pytest pip
 checkLastExitCode
 
 # In case of older python versions there isn't an up-to-date version of pip
@@ -333,7 +335,8 @@ if ($env:NUMPY_VERSION) {
     } else {
         $NUMPY_OPTION = "numpy=" + $env:NUMPY_VERSION
     }
-    retry_on_known_error conda install -n test $QUIET $NUMPY_OPTION
+    # Pulled out retry_on_known_error
+    conda install -n test $QUIET $NUMPY_OPTION
     checkLastExitCode
 } else {
     $NUMPY_OPTION = ""
@@ -355,7 +358,8 @@ if ($env:ASTROPY_VERSION) {
         $ASTROPY_OPTION = "astropy=" + $env:ASTROPY_VERSION
     }
     if ($env:PIP_FALLBACK -match "True") {
-      $output = retry_on_known_error conda install -n test $QUIET $NUMPY_OPTION $ASTROPY_OPTION.Split(" ")
+      # Pulled out retry_on_known_error
+      $output = conda install -n test $QUIET $NUMPY_OPTION $ASTROPY_OPTION.Split(" ")
       Write-Host $output
       if ($output | select-string UnsatisfiableError) {
          Write-Warning "Installing astropy with conda was unsuccessful, using pip instead"
@@ -366,7 +370,8 @@ if ($env:ASTROPY_VERSION) {
         checkLastExitCode
       }
     } else {
-      retry_on_known_error conda install -n test $QUIET $NUMPY_OPTION $ASTROPY_OPTION.Split(" ")
+      # Pulled out retry_on_known_error
+      conda install -n test $QUIET $NUMPY_OPTION $ASTROPY_OPTION.Split(" ")
       checkLastExitCode
     }
 
@@ -384,7 +389,8 @@ if ($env:SUNPY_VERSION) {
         $SUNPY_OPTION = "sunpy=" + $env:SUNPY_VERSION
     }
     if ($env:PIP_FALLBACK -match "True") {
-      $output = retry_on_known_error conda install -n test $QUIET $NUMPY_OPTION $SUNPY_OPTION
+      # Pulled out retry_on_known_error
+      $output = conda install -n test $QUIET $NUMPY_OPTION $SUNPY_OPTION
       Write-Host $output
       if ($output | select-string UnsatisfiableError) {
          Write-Warning "Installing sunpy with conda was unsuccessful, using pip instead"
@@ -395,7 +401,8 @@ if ($env:SUNPY_VERSION) {
         checkLastExitCode
       }
     } else {
-      retry_on_known_error conda install -n test $QUIET $NUMPY_OPTION $SUNPY_OPTION
+      # Pulled out retry_on_known_error
+      conda install -n test $QUIET $NUMPY_OPTION $SUNPY_OPTION
       checkLastExitCode
     }
 } else {
@@ -413,7 +420,8 @@ if ($env:CONDA_DEPENDENCIES) {
 if ($NUMPY_OPTION -or $CONDA_DEPENDENCIES) {
 
   if ($env:PIP_FALLBACK -match "True") {
-    $output = retry_on_known_error conda install -n test $QUIET $NUMPY_OPTION $CONDA_DEPENDENCIES
+    # Pulled out retry_on_known_error
+    $output = conda install -n test $QUIET $NUMPY_OPTION $CONDA_DEPENDENCIES
     Write-Host $output
     if ($output | select-string UnsatisfiableError, PackageNotFoundError, PackagesNotFoundError) {
        Write-Warning "Installing dependencies with conda was unsuccessful, using pip instead"
@@ -423,7 +431,8 @@ if ($NUMPY_OPTION -or $CONDA_DEPENDENCIES) {
       checkLastExitCode
     }
   } else {
-    retry_on_known_error conda install -n test $QUIET $NUMPY_OPTION $CONDA_DEPENDENCIES
+    # Pulled out retry_on_known_error
+    conda install -n test $QUIET $NUMPY_OPTION $CONDA_DEPENDENCIES
     checkLastExitCode
   }
 

--- a/appveyor/install-miniconda.ps1
+++ b/appveyor/install-miniconda.ps1
@@ -107,7 +107,7 @@ function retry_on_known_error {
                                               -Action $_output_event_handler `
                                               -EventName 'ErrorDataReceived' `
                                               -MessageData $_stderr_builder
-        $_process.Start() | Out-Null
+        $_process.Start()
         $_process.BeginOutputReadLine()
         $_process.BeginErrorReadLine()
         $_process.WaitForExit()

--- a/appveyor/install-miniconda.ps1
+++ b/appveyor/install-miniconda.ps1
@@ -316,7 +316,7 @@ if ($env:DEBUG) {
 }
 
 # Pulled out retry_on_known_error
-conda install $QUIET -n test pytest pip
+conda install $QUIET -n test pytest"$env:PYTEST_VERSION" pip
 checkLastExitCode
 
 # In case of older python versions there isn't an up-to-date version of pip

--- a/appveyor/install-miniconda.ps1
+++ b/appveyor/install-miniconda.ps1
@@ -276,13 +276,12 @@ checkLastExitCode
 
 # Create a conda environment using the astropy bonus packages
 if (! $env:CONDA_ENVIRONMENT ) {
-   retry_on_known_error conda create $QUIET -n test python=$env:PYTHON_VERSION
+   # This was preceded by retry_on_known_error but that
+   # appears to be broken.
+   conda create $QUIET -n test python=$env:PYTHON_VERSION
 } else {
-   retry_on_known_error conda env create $QUIET -n test -f $env:CONDA_ENVIRONMENT
+   conda env create $QUIET -n test -f $env:CONDA_ENVIRONMENT
 }
-checkLastExitCode
-
-conda create $QUIET -n test
 checkLastExitCode
 
 conda activate test


### PR DESCRIPTION
Builds are failing on appveyor very early in the setup process. The issue is https://github.com/conda/conda/issues/8836, though the most useful bits are at https://github.com/conda/conda/issues/8836#issuecomment-508815777 and the changes are based on https://github.com/geopandas/geopandas/pull/1029/files

I don't have a windows machine handy, so we'll see what appveyor thinks about this...