### PR TITLE
Switch to conda 4.7 as the default conda  and use flexible in place of true

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -163,7 +163,7 @@ matrix:
         # Limit attrs version as newer ones break old pytest
         - os: linux
           env: SETUP_CMD='build_docs' PYTHON_VERSION=2.7 ASTROPY_VERSION='stable'
-               CONDA_DEPENDENCY='attrs<19.2'
+               CONDA_DEPENDENCIES='attrs<19.2'
 
         # JOB .15
         - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,11 +60,6 @@ matrix:
         #    is 10.0.1 while the latest is 18.0 at the time of writing this test.
         # -> The latest version of pip as of 2019-08-15 on default channels is 19.2.2
         #    for Python >=3.6, so bump the pip version check to minimum of 19.
-        # Updated these versions because of availability of packages on the default
-        # channels:
-        #
-        #    PYTHON_VERSION 3.5 → 3.6
-        #    pip minimum version >17 → >18
         - os: linux
           env: SETUP_CMD='build_docs' SPHINX_VERSION='>1.6'
                PYTHON_VERSION=3.6 DEBUG=True
@@ -127,26 +122,12 @@ matrix:
 
         # JOB .11
         # -> Setting pytest version should be recognized in the next two jobs
-        #
-        # Changed version numbers in 2019 because older versions are no longer
-        # available in default conda channels:
-        #
-        #    matplotlib 1.5.0 → 2.2.0
-        #    pytest 2.7.3 → 4.6.4
         - os: linux
           env: SETUP_CMD='build_sphinx' CONDA_DEPENDENCIES='matplotlib>2.0,<=2.2.0'
                DEBUG=True PYTHON_VERSION=2.7 PYTEST_VERSION=4.6.4
                TEST_CMD='conda list; python -c "import matplotlib; assert matplotlib.__version__==\"2.2.0\"; import pytest; assert pytest.__version__.startswith(\"4.6.4\")"'
 
         # JOB .12
-        # Changed version numbers in 2019 because older versions are no longer
-        # available in default conda channels:
-        #
-        #    PYTHON_VERSION 3.5 → 3.6
-        #    MATPLOTLIB_VERSION 1.4 → 3.0 (and expected installed version 3.0.3)
-        #    SPHINX_VERSION 1.4.1 → 1.8.4
-        #    PYTEST_VERSION 3.0 → 5.0
-        #
         - os: linux
           env: SETUP_CMD='build_sphinx' SPHINX_VERSION=1.8.4 DEBUG=True
                MATPLOTLIB_VERSION=3.0 DEBUG=True PYTHON_VERSION=3.6 PYTEST_VERSION=5.0
@@ -212,8 +193,8 @@ matrix:
         #    can make sure the conda config was correctly updated.
         # -> Have a package dependency with alphanumerical name
         #
-        # -> The old cahnnel priority "true" is equivalent to the new priority
-        #    strict.
+        # -> The old channel priority "true" is equivalent to the new priority
+        #    "flexible".
         - os: linux
           env: SETUP_CMD='test' NUMPY_VERSION=1.10 CONDA_CHANNEL_PRIORITY=flexible
                CONDA_DEPENDENCIES='jinja2=2.8 h5py matplotlib' DEBUG=True

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ matrix:
           addons:
               apt:
                   packages: gfortran
-          env: NUMPY_VERSION=stable CONDA_DEPENDENCIES='healpy matplotlib scikit-learn scipy Pillow'
+          env: NUMPY_VERSION=stable CONDA_DEPENDENCIES='healpy matplotlib scikit-learn scipy pillow'
                CONDA_CHANNELS='conda-forge' DEBUG=True
                SUNPY_VERSION=dev MATPLOTLIB_VERSION='dev'
                SCIKIT_LEARN_VERSION='dev'

--- a/.travis.yml
+++ b/.travis.yml
@@ -93,7 +93,7 @@ matrix:
                PYTEST_VERSION="<3.6.2"
 
         # JOB .7
-        # -> Have non Python package (libcxx) in dependency list when
+        # -> Have non Python package (libtiff) in dependency list when
         #    falling back on pip installing the dependencies (as ipyevents is
         #    missing from listed channels) to test the install one-by-one.
         # -> Have package dependency that matches partially another package
@@ -109,8 +109,8 @@ matrix:
           env: SETUP_CMD='test --coverage' PYTHON_VERSION=3.6
                TEST_CMD='conda list; py.test test_env.py && coverage run test_env.py; python -c "import ipyevents; assert ipyevents.__version__.startswith(\"0.4\")"'
                CONDA_CHANNELS=''
-               CONDA_DEPENDENCIES='libcxx pytest pytest-cov ipyevents'
-               DEBUG=True NUMPY_VERSION=1.15 ASTROPY_VERSION=stable
+               CONDA_DEPENDENCIES='libtiff pytest pytest-cov ipyevents'
+               DEBUG=True ASTROPY_VERSION=stable
                IPYEVENTS_VERSION='<0.5,>=0.4'
 
         # JOB .8

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,16 +13,20 @@ env:
         - SETUP_CMD='test'
         - TEST_CMD='py.test test_env.py'
         - PYTHON_VERSION=3.6
+        - DEBUG=True
 
     matrix:
         - SETUP_CMD='egg_info' TEST_CMD='python --version'
 
 matrix:
     include:
+        # JOB .1
         # pytest pip fallback, conda package for 3.1 is not available for py3.4
         - os: linux
           env: PYTHON_VERSION=3.4 PYTEST_VERSION=3.1
 
+        # JOB .33 (because it is under allowed failures)
+        # NOTE: IT DOES NOT CURRENTLY FAIL
         # Try pytest pip fallback as conda package for 3.1 is not available
         # for py3.4 but then fail as PIP_FALLBACK is False. Listing this
         # under the allowed failures as there is no way at the moment to
@@ -30,9 +34,11 @@ matrix:
         - os: linux
           env: PYTHON_VERSION=3.4 PYTEST_VERSION=3.1 PIP_FALLBACK=false
 
+        # JOB .2
         - os: windows
           env: PYTHON_VERSION=3.7
 
+        # JOB .3
         # -> tests sunpy dev
         # -> Test falling back on pip when conda install is not working.
         #    Here healpy is not available with numpy >=1.13
@@ -48,14 +54,23 @@ matrix:
                SUNPY_VERSION=dev MATPLOTLIB_VERSION='dev'
                SCIKIT_LEARN_VERSION='dev'
 
+        # JOB .4
         # -> Testing whether pip install fallback is working for sphinx/matplotlib in the docs builds
         # -> Test we have a recent pip version, the newest on the defaults channel
         #    is 10.0.1 while the latest is 18.0 at the time of writing this test.
+        # -> The latest version of pip as of 2019-08-15 on default channels is 19.2.2
+        #    for Python >=3.6, so bump the pip version check to minimum of 19.
+        # Updated these versions because of availability of packages on the default
+        # channels:
+        #
+        #    PYTHON_VERSION 3.5 → 3.6
+        #    pip minimum version >17 → >18
         - os: linux
           env: SETUP_CMD='build_docs' SPHINX_VERSION='>1.6'
-               PYTHON_VERSION=3.5 DEBUG=True
-               TEST_CMD='python -c "import sphinx; from distutils.version import LooseVersion; assert LooseVersion(sphinx.__version__)>LooseVersion(\"1.5\"); import pip; assert int(pip.__version__.split(\".\")[0])>17"'
+               PYTHON_VERSION=3.6 DEBUG=True
+               TEST_CMD='python -c "import sphinx; from distutils.version import LooseVersion; assert LooseVersion(sphinx.__version__)>LooseVersion(\"1.5\"); import pip; assert int(pip.__version__.split(\".\")[0])>18"'
 
+        # JOB .5
         # -> tests sunpy stable
         # -> Starting with the dev versions as they take the longest to run. We
         #    deliberately test with Numpy 1.16 to check that installing Astropy
@@ -64,6 +79,7 @@ matrix:
           env: SETUP_CMD='test' NUMPY_VERSION=1.16 ASTROPY_VERSION=dev
                PYTHON_VERSION=3.6 SUNPY_VERSION=stable CONDA_CHANNELS='conda-forge'
 
+        # JOB .6
         # -> For the Numpy dev build, we also specify a conda package that
         #    depends on Numpy to make sure that Numpy dev is used (because
         #    conda will also install Numpy stable). It's also important to
@@ -76,139 +92,189 @@ matrix:
                CONDA_DEPENDENCIES='scipy'
                PYTEST_VERSION="<3.6.2"
 
+        # JOB .7
         # -> Have non Python package (openjpeg) in dependency list when
-        #    falling back on pip installing the dependencies (as photutils is
-        #    missing from listed channels) to test the install one-by-one.
+        #    falling back on pip installing the dependencies (as pyqt5 is
+        #    missing from listed channels where it is called pyqt) to test the install one-by-one.
         # -> Have package dependency that matches partially another package
         #    (pytest vs pytest-cov) when falling back to pip install
         # -> testing whether version numbers are respected by pip install fallback
+        # The following versions were updated in 2019 because the old versions
+        # were leading to issues because anaconda deprecated the old free channel:
+        #
+        #    PYTHON_VERSION 3.4 → 3.6
+        #    NUMPY_VERSION 1.10 → 1.16
+        #
         - os: linux
-          env: SETUP_CMD='test --coverage' PYTHON_VERSION=3.4
-               TEST_CMD='py.test test_env.py && coverage run test_env.py; python -c "import sklearn; assert sklearn.__version__.startswith(\"0.19\")"'
+          env: SETUP_CMD='test --coverage' PYTHON_VERSION=3.6
+               TEST_CMD='conda list; py.test test_env.py && coverage run test_env.py; python -c "import sklearn; assert sklearn.__version__.startswith(\"0.19\")"'
                CONDA_CHANNELS='astrofrog conda-forge'
                CONDA_DEPENDENCIES='scipy pyqt5 openjpeg photutils pytest pytest-cov scikit-learn'
-               DEBUG=True NUMPY_VERSION=1.10 ASTROPY_VERSION=stable
+               DEBUG=True NUMPY_VERSION=1.15 ASTROPY_VERSION=stable
                SCIKIT_LEARN_VERSION='<0.20,>=0.19'
 
+        # JOB .8
         # -> The pre builds should run the testing phase only when a pre
         #    release is available on pypi, otherwise it should pass
         - os: linux
           env: SETUP_CMD='test' NUMPY_VERSION=pre
+        # JOB .9
         - os: linux
           env: SETUP_CMD='test' ASTROPY_VERSION=pre DEBUG=True
+        # JOB .10
         - os: linux
           env: SUNPY_VERSION=prerelease CONDA_CHANNELS='conda-forge'
 
+        # JOB .11
         # -> Setting pytest version should be recognized in the next two jobs
+        #
+        # Changed version numbers in 2019 because older versions are no longer
+        # available in default conda channels:
+        #
+        #    matplotlib 1.5.0 → 2.2.0
+        #    pytest 2.7.3 → 4.6.4
         - os: linux
-          env: SETUP_CMD='build_sphinx' CONDA_DEPENDENCIES='matplotlib<=1.5.0'
-               DEBUG=True PYTHON_VERSION=2.7 PYTEST_VERSION=2.7.3
-               TEST_CMD='python -c "import matplotlib; assert matplotlib.__version__==\"1.5.0\"; import pytest; assert pytest.__version__.startswith(\"2.7.3\")"'
+          env: SETUP_CMD='build_sphinx' CONDA_DEPENDENCIES='matplotlib>2.0,<=2.2.0'
+               DEBUG=True PYTHON_VERSION=2.7 PYTEST_VERSION=4.6.4
+               TEST_CMD='conda list; python -c "import matplotlib; assert matplotlib.__version__==\"2.2.0\"; import pytest; assert pytest.__version__.startswith(\"4.6.4\")"'
 
+        # JOB .12
+        # Changed version numbers in 2019 because older versions are no longer
+        # available in default conda channels:
+        #
+        #    PYTHON_VERSION 3.5 → 3.6
+        #    MATPLOTLIB_VERSION 1.4 → 3.0 (and expected installed version 3.0.3)
+        #    SPHINX_VERSION 1.4.1 → 1.8.4
+        #    PYTEST_VERSION 3.0 → 5.0
+        #
         - os: linux
-          env: SETUP_CMD='build_sphinx' SPHINX_VERSION=1.4.1 DEBUG=True
-               MATPLOTLIB_VERSION=1.4 DEBUG=True PYTHON_VERSION=3.5 PYTEST_VERSION=3.0
-               TEST_CMD='python -c "import sphinx; assert sphinx.__version__==\"1.4.1\"; import pytest; pytest.__version__.startswith(\"3.0\"); import matplotlib; assert matplotlib.__version__=="\""1.4.3"\"'
+          env: SETUP_CMD='build_sphinx' SPHINX_VERSION=1.8.4 DEBUG=True
+               MATPLOTLIB_VERSION=3.0 DEBUG=True PYTHON_VERSION=3.6 PYTEST_VERSION=5.0
+               TEST_CMD='python -c "import sphinx; assert sphinx.__version__==\"1.8.4\"; import pytest; pytest.__version__.startswith(\"5.0\"); import matplotlib; assert matplotlib.__version__=="\""3.0.3"\"'
 
+        # JOB .13
         - os: linux
           env: SETUP_CMD='test' CONDA_DEPENDENCIES='matplotlib=1.5.0 sphinx'
                MATPLOTLIB_VERSION=1.5.1 DEBUG=True PYTHON_VERSION=3.5
                TEST_CMD='python -c "import matplotlib; assert matplotlib.__version__=="\""1.5.1"\"'
 
+        # JOB .14
         # -> astropy stable should stay on the 2.0.x branch
         # Limit attrs version as newer ones break old pytest
         - os: linux
           env: SETUP_CMD='build_docs' PYTHON_VERSION=2.7 ASTROPY_VERSION='stable'
                CONDA_DEPENDENCY='attrs<19.2'
 
+        # JOB .15
         - os: linux
           env: MAIN_CMD='pep8'
                TEST_CMD='pep8 --version'
 
+        # JOB .16
         - os: linux
           env: MAIN_CMD='pycodestyle'
                TEST_CMD='pycodestyle --version'
 
+        # JOB .17
         - os: linux
           env: MAIN_CMD='flake8'
                TEST_CMD='flake8 --version'
 
+        # JOB .18
         - os: linux
           env: MAIN_CMD='pylint'
                TEST_CMD='pylint --version'
 
+        # JOB .19
         - os: linux
           env: SETUP_CMD="--cov package"
                TEST_CMD='python -c "import pytest_cov"'
 
+        # JOB .20
         # -> Don't test osx with LTS as we currently build LTS only for linux.
         - os: osx
           env: SETUP_CMD='test' ASTROPY_VERSION=stable
                CONDA_DEPENDENCIES='requests'
 
-        # -> Note that setting CONDA_CHANNEL_PRIORITY to False here is unrelated
+        # JOB .21
+        # -> Note that setting CONDA_CHANNEL_PRIORITY to disabled here is unrelated
         #    to the rest of the build and won't change anything, except that we
         #    can make sure the conda config was correctly updated.
         - os: linux
           env: SETUP_CMD='test' NUMPY_VERSION=1.10 DEBUG=True
                SCIKIT_IMAGE_VERSION=0.11 PYTHON_VERSION=3.5
                CONDA_DEPENDENCIES='Cython numpy scikit-image'
-               CONDA_CHANNEL_PRIORITY=False
+               CONDA_CHANNEL_PRIORITY=disabled
 
-        # -> Note that setting CONDA_CHANNEL_PRIORITY to strict here is unrelated
+        # JOB .22
+        # -> Note that setting CONDA_CHANNEL_PRIORITY to flexible here is unrelated
         #    to the rest of the build and won't change anything, except that we
         #    can make sure the conda config was correctly updated.
         # -> Have a package dependency with alphanumerical name
+        #
+        # -> The old cahnnel priority "true" is equivalent to the new priority
+        #    strict.
         - os: linux
-          env: SETUP_CMD='test' NUMPY_VERSION=1.10 CONDA_CHANNEL_PRIORITY=strict
+          env: SETUP_CMD='test' NUMPY_VERSION=1.10 CONDA_CHANNEL_PRIORITY=flexible
                CONDA_DEPENDENCIES='jinja2=2.8 h5py matplotlib' DEBUG=True
                ASTROPY_VERSION=1.0 CONDA_CHANNELS='astropy'
                PYTHON_VERSION='3.5'
 
+        # JOB .23
         # -> Have empty string as dependency list when falling back on pip
         # Limit attrs version as newer ones break old pytest
         - os: linux
           env: SETUP_CMD='test' NUMPY_VERSION=stable ASTROPY_VERSION=lts
                CONDA_DEPENDENCIES='attrs<19.2'
 
+        # JOB .24
         - os: linux
           env: SETUP_CMD='test' CONDA_DEPENDENCIES='matplotlib=1.5'
                TEST_CMD='python -c "import matplotlib; assert int(matplotlib.__version__[-1])>0"'
 
+        # JOB .25
         - os: linux
           env: SETUP_CMD='test --parallel'
                TEST_CMD='py.test -n 4 test_env.py'
 
+        # JOB .26
         - os: linux
           env: SETUP_CMD='test --numprocesses'
                TEST_CMD='py.test --numprocesses 4 test_env.py'
 
+        # JOB .27
         - os: linux
           env: SETUP_CMD='test --open-files'
 
+        # JOB .28
         - os: linux
           env: SETUP_CMD='test' CONDA_DEPENDENCIES='matplotlib'
                CONDA_DEPENDENCIES_FLAGS='--no-deps'
                NUMPY_VERSION=1.16 PYTHON_VERSION=3.5
 
+        # JOB .29
         - os: linux
           env: SETUP_CMD='test' CONDA_DEPENDENCIES='matplotlib'
                CONDA_DEPENDENCIES_FLAGS='--no-deps'
                NUMPY_VERSION=1.16.1 PYTHON_VERSION=3.5
 
+        # JOB .30
         - os: linux
           env: SETUP_CMD='test' PIP_DEPENDENCIES='pyparsing requests'
                PIP_DEPENDENCIES_FLAGS='--log pip_install.log'
 
+        # JOB .31
         - os: linux
           env: SETUP_CMD='test' CONDA_ENVIRONMENT='conda_environment.yml'
                TEST_CMD="python -c $'import matplotlib\ntry:\n    import scipy\nexcept ImportError:\n    pass\nelse:\n    raise RuntimeError'"
 
+        # JOB .32
         - os: linux
           env: SETUP_CMD='test' CONDA_ENVIRONMENT='conda_environment.yml' CONDA_DEPENDENCIES="scipy"
                TEST_CMD="python -c $'import matplotlib\nimport scipy'"
 
     allow_failures:
+        # JOB .33
         - os: linux
           env: PYTHON_VERSION=3.4 PYTEST_VERSION=3.1 PIP_FALLBACK=false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -155,12 +155,12 @@ matrix:
                CONDA_DEPENDENCIES='Cython numpy scikit-image'
                CONDA_CHANNEL_PRIORITY=False
 
-        # -> Note that setting CONDA_CHANNEL_PRIORITY to True here is unrelated
+        # -> Note that setting CONDA_CHANNEL_PRIORITY to strict here is unrelated
         #    to the rest of the build and won't change anything, except that we
         #    can make sure the conda config was correctly updated.
         # -> Have a package dependency with alphanumerical name
         - os: linux
-          env: SETUP_CMD='test' NUMPY_VERSION=1.10 CONDA_CHANNEL_PRIORITY=True
+          env: SETUP_CMD='test' NUMPY_VERSION=1.10 CONDA_CHANNEL_PRIORITY=strict
                CONDA_DEPENDENCIES='jinja2=2.8 h5py matplotlib' DEBUG=True
                ASTROPY_VERSION=1.0 CONDA_CHANNELS='astropy'
                PYTHON_VERSION='3.5'

--- a/.travis.yml
+++ b/.travis.yml
@@ -93,25 +93,25 @@ matrix:
                PYTEST_VERSION="<3.6.2"
 
         # JOB .7
-        # -> Have non Python package (openjpeg) in dependency list when
-        #    falling back on pip installing the dependencies (as pyqt5 is
-        #    missing from listed channels where it is called pyqt) to test the install one-by-one.
+        # -> Have non Python package (libcxx) in dependency list when
+        #    falling back on pip installing the dependencies (as ipyevents is
+        #    missing from listed channels) to test the install one-by-one.
         # -> Have package dependency that matches partially another package
         #    (pytest vs pytest-cov) when falling back to pip install
         # -> testing whether version numbers are respected by pip install fallback
-        # The following versions were updated in 2019 because the old versions
-        # were leading to issues because anaconda deprecated the old free channel:
         #
-        #    PYTHON_VERSION 3.4 → 3.6
-        #    NUMPY_VERSION 1.10 → 1.16
+        # The list of dependencies was considerably simplified to speed up the
+        # (expected) conda failure.
         #
+        # Need to omit conda-forge from channels here because ipyevents is on conda-forge
+        # and we want the pip fallback to happen.
         - os: linux
           env: SETUP_CMD='test --coverage' PYTHON_VERSION=3.6
-               TEST_CMD='conda list; py.test test_env.py && coverage run test_env.py; python -c "import sklearn; assert sklearn.__version__.startswith(\"0.19\")"'
-               CONDA_CHANNELS='astrofrog conda-forge'
-               CONDA_DEPENDENCIES='scipy pyqt5 openjpeg photutils pytest pytest-cov scikit-learn'
+               TEST_CMD='conda list; py.test test_env.py && coverage run test_env.py; python -c "import ipyevents; assert ipyevents.__version__.startswith(\"0.4\")"'
+               CONDA_CHANNELS=''
+               CONDA_DEPENDENCIES='libcxx pytest pytest-cov ipyevents'
                DEBUG=True NUMPY_VERSION=1.15 ASTROPY_VERSION=stable
-               SCIKIT_LEARN_VERSION='<0.20,>=0.19'
+               IPYEVENTS_VERSION='<0.5,>=0.4'
 
         # JOB .8
         # -> The pre builds should run the testing phase only when a pre

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ env:
         - SETUP_CMD='test'
         - TEST_CMD='py.test test_env.py'
         - PYTHON_VERSION=3.6
-        - DEBUG=True
 
     matrix:
         - SETUP_CMD='egg_info' TEST_CMD='python --version'

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ environment variables
   be ``SCIKIT_IMAGE_VERSION``). If specified it will override any version
   number limitations listed in ``CONDA_DEPENDENCIES``.
 
-* ``CONDA_CHANNEL_PRIORITY``: can be set to ``strict``, ``flexible`` or ``false``, and
+* ``CONDA_CHANNEL_PRIORITY``: can be set to ``strict``, ``flexible`` or ``disabled``, and
   affects the ``channel_priority`` conda setting (as discussed
   [here](https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-channels.html). The default is
   ``false``.

--- a/README.md
+++ b/README.md
@@ -143,10 +143,10 @@ environment variables
   be ``SCIKIT_IMAGE_VERSION``). If specified it will override any version
   number limitations listed in ``CONDA_DEPENDENCIES``.
 
-* ``CONDA_CHANNEL_PRIORITY``: can be set to ``True`` or ``False``, and
+* ``CONDA_CHANNEL_PRIORITY``: can be set to ``strict``, ``flexible`` or ``false``, and
   affects the ``channel_priority`` conda setting (as discussed
-  [here](http://conda.pydata.org/docs/channels.html). The default is
-  ``False``.
+  [here](https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-channels.html). The default is
+  ``false``.
 
 * ``EVENT_TYPE``: this should be a space-separated string of event
   types. If given, the build will run only if the ``TRAVIS_EVENT_TYPE``

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ environment variables
 * ``CONDA_CHANNEL_PRIORITY``: can be set to ``strict``, ``flexible`` or ``disabled``, and
   affects the ``channel_priority`` conda setting (as discussed
   [here](https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-channels.html). The default is
-  ``false``.
+  ``disabled``.
 
 * ``EVENT_TYPE``: this should be a space-separated string of event
   types. If given, the build will run only if the ``TRAVIS_EVENT_TYPE``

--- a/appveyor/install-miniconda.ps1
+++ b/appveyor/install-miniconda.ps1
@@ -229,7 +229,7 @@ function InstallMiniconda ($miniconda_version, $architecture, $python_home) {
 if (! $env:MINICONDA_VERSION) {
    # Note that we pin the Miniconda version to avoid issues when new versions are released.
    # This can be updated from time to time.
-   $env:MINICONDA_VERSION="4.5.12"
+   $env:MINICONDA_VERSION="4.7.10"
 }
 
 InstallMiniconda $env:MINICONDA_VERSION $env:PLATFORM $env:PYTHON

--- a/appveyor/install-miniconda.ps1
+++ b/appveyor/install-miniconda.ps1
@@ -159,7 +159,7 @@ $env:LATEST_SUNPY_STABLE = "1.0.1"
 # We pin the version for conda as it's not the most stable package from
 # release to release. Add note here if version is pinned due to a bug upstream.
 if (! $env:CONDA_VERSION) {
-   $env:CONDA_VERSION = "4.5.10"
+   $env:CONDA_VERSION = "4.7"
 }
 
 if (! $env:PIP_FALLBACK) {

--- a/test_env.py
+++ b/test_env.py
@@ -188,6 +188,8 @@ def test_dependency_imports():
             continue
         elif package == '':
             continue
+        elif package == "pillow":
+            __import__('PIL')
         else:
             __import__(package)
 

--- a/test_env.py
+++ b/test_env.py
@@ -188,8 +188,6 @@ def test_dependency_imports():
             continue
         elif package == '':
             continue
-        elif package == "pillow":
-            __import__('PIL')
         else:
             __import__(package)
 

--- a/test_env.py
+++ b/test_env.py
@@ -252,7 +252,7 @@ def test_regression_mkl():
 
 def test_conda_channel_priority():
 
-    channel_priority = os.environ.get('CONDA_CHANNEL_PRIORITY', 'disabled' if 'APPVEYOR' in os.environ else 'False')
+    channel_priority = os.environ.get('CONDA_CHANNEL_PRIORITY', 'disabled')
 
     with open(os.path.expanduser('~/.condarc'), 'r') as f:
         content = f.read()

--- a/travis/hack_version_numbers.py
+++ b/travis/hack_version_numbers.py
@@ -1,0 +1,46 @@
+import sys
+import re
+
+pkg_pat1 = re.compile(r'.+pinned spec ([^><=\[]+)=(.+) conflicts.+')
+pkg_pat2 = re.compile(r'.+pinned spec ([^><=[]+)(\[.+?\]) conflicts.+')
+
+spec_conflicts = sys.argv[1]
+
+if len(sys.argv) == 3:
+    # We got the conda command in one shot
+    original_args = sys.argv[2].split(" ")
+else:
+    # The arguments were split by the shell
+    original_args = sys.argv[2:]
+
+# Just crash if the command wasn't actually conda install
+assert original_args[0] == 'conda'
+assert original_args[1] == 'install'
+
+with open(spec_conflicts) as f:
+    lines = f.readlines()
+
+versions = dict()
+
+for line in lines:
+    # Packages with overriden specs will match either pattern 1 or 2
+    match = pkg_pat1.match(line)
+    if not match:
+        match = pkg_pat2.match(line)
+
+    if match:
+        package = match.group(1)
+        versions[package] = "=" + match.group(2)
+
+new_args = []
+
+for arg in original_args:
+    if arg in versions:
+        # Add a version spec
+        pkg_version = versions[arg]
+        new_args.append(arg + pkg_version)
+    else:
+        new_args.append(arg)
+
+# Our "return" value is a new command with pinned specs
+print(" ".join(new_args))

--- a/travis/hack_version_numbers.py
+++ b/travis/hack_version_numbers.py
@@ -32,9 +32,10 @@ for line in lines:
         package = match.group(1)
         versions[package] = "=" + match.group(2)
 
-new_args = []
+# We never want to add a spec to the "conda install" part of the command
+new_args = original_args[:2]
 
-for arg in original_args:
+for arg in original_args[2:]:
     if arg in versions:
         # Add a version spec
         pkg_version = versions[arg]

--- a/travis/setup_conda.sh
+++ b/travis/setup_conda.sh
@@ -7,6 +7,7 @@
 #
 # The present script was added later.
 
+export DEBUG="True"
 if [[ $DEBUG == True ]]; then
     set -x
 fi

--- a/travis/setup_conda.sh
+++ b/travis/setup_conda.sh
@@ -7,7 +7,6 @@
 #
 # The present script was added later.
 
-export DEBUG="True"
 if [[ $DEBUG == True ]]; then
     set -x
 fi

--- a/travis/setup_conda_linux.sh
+++ b/travis/setup_conda_linux.sh
@@ -4,11 +4,13 @@
 # Note that we pin the Miniconda version to avoid issues when new versions are released.
 # This can be updated from time to time.
 if [[ -z "${MINICONDA_VERSION}" ]]; then
-    MINICONDA_VERSION=4.5.12
+    MINICONDA_VERSION=4.7.10
 fi
 wget https://repo.continuum.io/miniconda/Miniconda3-${MINICONDA_VERSION}-Linux-x86_64.sh -O miniconda.sh --progress=dot:mega
 bash miniconda.sh -b -p $HOME/miniconda
-export PATH="$HOME/miniconda/bin:$PATH"
+$HOME/miniconda/bin/conda init bash
+source ~/.bash_profile
+conda activate base
 
 # Install common Python dependencies
 source "$( dirname "${BASH_SOURCE[0]}" )"/setup_dependencies_common.sh

--- a/travis/setup_conda_linux.sh
+++ b/travis/setup_conda_linux.sh
@@ -7,6 +7,9 @@ if [[ -z "${MINICONDA_VERSION}" ]]; then
     MINICONDA_VERSION=4.7.10
 fi
 wget https://repo.continuum.io/miniconda/Miniconda3-${MINICONDA_VERSION}-Linux-x86_64.sh -O miniconda.sh --progress=dot:mega
+# Create .conda directory before install to workaround conda bug
+# See https://github.com/ContinuumIO/anaconda-issues/issues/11148
+mkdir $HOME/.conda
 bash miniconda.sh -b -p $HOME/miniconda
 $HOME/miniconda/bin/conda init bash
 source ~/.bash_profile

--- a/travis/setup_conda_osx.sh
+++ b/travis/setup_conda_osx.sh
@@ -26,6 +26,9 @@ elif [[ "${MACOSX_DEPLOYMENT_TARGET}" == "clang_default" ]]; then
 fi
 
 wget https://repo.continuum.io/miniconda/Miniconda3-${MINICONDA_VERSION}-MacOSX-x86_64.sh -O miniconda.sh
+# Create .conda directory before install to workaround conda bug
+# See https://github.com/ContinuumIO/anaconda-issues/issues/11148
+mkdir $HOME/.conda
 bash miniconda.sh -b -p $HOME/miniconda
 $HOME/miniconda/bin/conda init bash
 source ~/.bash_profile

--- a/travis/setup_conda_osx.sh
+++ b/travis/setup_conda_osx.sh
@@ -13,7 +13,7 @@ rvm get stable
 # Note that we pin the Miniconda version to avoid issues when new versions are released.
 # This can be updated from time to time.
 if [[ -z "${MINICONDA_VERSION}" ]]; then
-    MINICONDA_VERSION=4.5.12
+    MINICONDA_VERSION=4.7.10
 fi
 
 # Set default OSX deployment target version to 10.9, since this is required for
@@ -27,7 +27,9 @@ fi
 
 wget https://repo.continuum.io/miniconda/Miniconda3-${MINICONDA_VERSION}-MacOSX-x86_64.sh -O miniconda.sh
 bash miniconda.sh -b -p $HOME/miniconda
-export PATH="$HOME/miniconda/bin:$PATH"
+$HOME/miniconda/bin/conda init bash
+source ~/.bash_profile
+conda activate base
 
 # Install common Python dependencies
 source "$( dirname "${BASH_SOURCE[0]}" )"/setup_dependencies_common.sh

--- a/travis/setup_conda_windows.sh
+++ b/travis/setup_conda_windows.sh
@@ -6,12 +6,14 @@ if [[ $DEBUG == True ]]; then
 fi
 
 if [[ -z "${MINICONDA_VERSION}" ]]; then
-    MINICONDA_VERSION=4.5.4
+    MINICONDA_VERSION=4.6.14
 fi
 
 echo "installing miniconda3"
 choco install miniconda3 --params="'/AddToPath:1'" --version="$MINICONDA_VERSION";
-export PATH="/c/tools/miniconda3/scripts:/c/tools/miniconda3/:$PATH";
+/c/tools/miniconda3/scripts/conda init bash
+source "/c/Users/travis/.bash_profile"
+conda activate base
 
 PIN_FILE_CONDA="/c/tools/miniconda3/conda-meta/pinned"
 PIN_FILE="/c/tools/miniconda3/envs/test/conda-meta/pinned"

--- a/travis/setup_conda_windows.sh
+++ b/travis/setup_conda_windows.sh
@@ -6,7 +6,7 @@ if [[ $DEBUG == True ]]; then
 fi
 
 if [[ -z "${MINICONDA_VERSION}" ]]; then
-    MINICONDA_VERSION=4.7.10
+    MINICONDA_VERSION=4.6.14
 fi
 
 echo "installing miniconda3"

--- a/travis/setup_conda_windows.sh
+++ b/travis/setup_conda_windows.sh
@@ -6,7 +6,7 @@ if [[ $DEBUG == True ]]; then
 fi
 
 if [[ -z "${MINICONDA_VERSION}" ]]; then
-    MINICONDA_VERSION=4.6.14
+    MINICONDA_VERSION=4.7.10
 fi
 
 echo "installing miniconda3"

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -37,14 +37,55 @@ function retry_on_known_error() {
         echo "ERROR: Function retry_on_known_error() called without arguments." 1>&2
         return 1
     fi
+    _tmp_output_file="tmp.txt"
     _n_retries=0
     _exitval=0
     _retry=true
     while $_retry; do
         _retry=false
-        # Execute the wrapped command and get its unified output:
-        _output=$($@ 2>&1)
-        _exitval="$?"
+        # Execute the wrapped command and get its unified output.
+        # This command needs to run in the current shell/environment in case
+        # it sets environment variables (like 'conda install' does)
+        #
+        # tee will both echo output to stdout and save it in a file. The file
+        # is needed for some error checks later. Output to stdout is needed in
+        # the event a conda solve takes a really long time (>10 min). If
+        # there is no output on travis for that long, the job is cancelled.
+        $@ 2>&1 | tee $_tmp_output_file
+        # Use PIPESTATUS to get the exit code for the first command in the pipe,
+        # nothe from the second command, tee, which always succeeds.
+        _exitval="${PIPESTATUS[0]}"
+
+        # The hack below is to work around a bug in conda 4.7 in which a spec
+        # pinned in a pin file is not respected if that package is listed
+        # explicitly on the command line even if there is no version spec on
+        # the command line. See:
+        #
+        #   https://github.com/conda/conda/issues/9052
+        #
+        # The hacky workaround is to identify overridden specs and add the
+        # spec from the pin file back to the command line.
+        if [[ -n $(grep "conflicts with explicit specs" $_tmp_output_file) ]]; then
+            _tmp_spec_conflicts=bad_spec.txt
+            # Isolate the problematic specs
+            grep "conflicts with explicit specs" $_tmp_output_file > $_tmp_spec_conflicts
+
+            # Do NOT turn the three lines below into one by putting the python in a
+            # $()...we need to make sure we stay in the shell in which conda is activated,
+            # not a subshell.
+            _tmp_updated_conda_command=new_command.txt
+            python ci-helpers/travis/hack_version_numbers.py $_tmp_spec_conflicts "$@" > $_tmp_updated_conda_command
+            revised_command=$(cat $_tmp_updated_conda_command)
+            echo $revised_command
+            # Try it; if it still has conflicts then just give up
+            $revised_command 2>&1 | tee $_tmp_output_file
+            _exitval="${PIPESTATUS[0]}"
+            if [[ -n $(grep "conflicts with explicit specs" $_tmp_output_file) ]]; then
+                echo "STOPPING conda attempts because unable to resolve conda pinning issues"
+                return 1
+            fi
+        fi
+
         # If the command was sucessful, abort the retry loop:
         if [ "$_exitval" == "0" ]; then
             break
@@ -55,7 +96,7 @@ function retry_on_known_error() {
             # If a known error string was found, throw a warning and wait a
             # certain number of seconds before invoking the command again:
             for _error in $RETRY_ERRORS; do
-                if [ -n "$(echo "$_output" | grep "$_error")" ]; then
+                if [ -n "$(grep "$_error" "$_tmp_output_file")" ]; then
                     echo "WARNING: The comand \"$@\" failed due to a $_error, retrying." 1>&2
                     _n_retries=$(($_n_retries + 1))
                     _retry=true
@@ -68,10 +109,14 @@ function retry_on_known_error() {
     # If the command succeeded, print its output to stdout (otherwise, print to
     # stderr):
     if [ "$_exitval" == "0" ]; then
-        echo "$_output"
+        cat "$_tmp_output_file"
     else
-        echo "$_output" 1>&2
+        cat "$_tmp_output_file" 1>&2
     fi
+
+    # remove the temporary output file
+    rm -f "$_tmp_output_file"
+
     # Finally, return the command's exit code:
     return $_exitval
 }
@@ -136,7 +181,7 @@ fi
 # We pin the version for conda as it's not the most stable package from
 # release to release. Add note here if version is pinned due to a bug upstream.
 if [[ -z $CONDA_VERSION ]]; then
-    CONDA_VERSION=4.7
+    CONDA_VERSION=4.7.11
 fi
 
 if [[ -z $PIN_FILE_CONDA ]]; then
@@ -148,7 +193,7 @@ echo "conda ${CONDA_VERSION}" > $PIN_FILE_CONDA
 retry_on_known_error conda install $QUIET conda
 
 if [[ -z $CONDA_CHANNEL_PRIORITY ]]; then
-    CONDA_CHANNEL_PRIORITY=false
+    CONDA_CHANNEL_PRIORITY=disabled
 else
     # Make lowercase
     CONDA_CHANNEL_PRIORITY=$(echo $CONDA_CHANNEL_PRIORITY | awk '{print tolower($0)}')
@@ -173,6 +218,14 @@ fi
 if [[ -z $MPLBACKEND ]]; then
     export MPLBACKEND=Agg
 fi
+
+
+# Python 3.4 is only available on conda's "free" channel, which was removed in
+# conda 4.7.
+if [[ $PYTHON_VERSION == 3.4* ]]; then
+    conda config --set restore_free_channel true
+fi
+
 
 # CONDA
 if [[ -z $CONDA_ENVIRONMENT ]]; then
@@ -233,8 +286,22 @@ retry_on_known_error conda install --no-channel-priority $QUIET $PYTHON_OPTION p
 # which may lead to ignore install dependencies of the package we test.
 # This update should not interfere with the rest of the functionalities
 # here.
+#
+# This *may* be leading to inconsistent conda environments, definitely means
+# that conda is not aware of pip installs, and is often overridden by
+# subsequent conda installs because conda is configured to install pip by
+# default now.
+#
+# For really old pythons it may be necessary, though, so check pip version and
+# install this way if the major version is less than 19.
 if [[ -z $PIP_VERSION ]]; then
-    $PIP_INSTALL --upgrade pip
+    old_pip=$(python -c "from distutils.version import LooseVersion;\
+                import os; import pip;\
+                print(LooseVersion(pip.__version__) <\
+                      LooseVersion('19.0.0'))")
+    if [[ $old_pip == True ]]; then
+        $PIP_INSTALL --upgrade pip
+    fi
 fi
 
 # PEP8
@@ -267,7 +334,7 @@ if [[ $MAIN_CMD == pylint* ]]; then
 fi
 
 # Pin required versions for dependencies, howto is in FAQ of conda
-# http://conda.pydata.org/docs/faq.html#pinning-packages
+# https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-pkgs.html#preventing-packages-from-updating-pinning
 if [[ ! -z $CONDA_DEPENDENCIES ]]; then
 
     if [[ -z $(echo $CONDA_DEPENDENCIES | grep '\bmkl\b') &&
@@ -313,7 +380,90 @@ if [[ ! -z $CONDA_DEPENDENCIES ]]; then
     fi
 fi
 
+if [[ ! -z $CONDA_DEPENDENCIES ]]; then
+    # Debugging....
+    echo "WHAT IS GOING ON HERE (TAKE 1)"
+    conda info -a
+    conda config --show
+    conda list
+    cat $PIN_FILE
+    # Do a dry run of the conda install here to make sure that pins are
+    # ACTUALLY being respected. This will become unnecessary when
+    # https://github.com/conda/conda/issues/9052
+    # is fixed
+
+    # Direct output to stdout and a file. The file is for later parsing,
+    # and stdout is so that travis knows something is happening if the solve
+    # takes a long time.
+    _tmp_output_file=dry_run.txt
+    conda install --dry-run $CONDA_DEPENDENCIES 2>&1 | tee $_tmp_output_file
+
+    # NOTE: it is important that the expression below remain in an if context
+    # because of the 'set -e' above, which causes the shell to immediately
+    # exit if the last command in a pipeline has a non-zero exit status,
+    # UNLESS the pipeline is in a few specific contexts.  From
+    # https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html:
+    #
+    #     The shell does not exit if the command that fails is ...part of the
+    #     test in an if statement...
+    #
+    # In the pipeline below, 'grep' returns non-zero exit status if no lines
+    # match.
+    if [[ ! -z $(grep "conflicts with explicit specs" $_tmp_output_file) ]]; then
+        echo "restoring free channel"
+        # Restoring the free channel only helps if the channel priority
+        # is not strict, so check that first. If it is strict, fail instead
+        # of changing the solve logic.
+
+        # ...but only if the free channel is not ruled out by strict
+        # channel priority
+        if [[ ! -z $CONDA_CHANNEL_PRIORITY && $CONDA_CHANNEL_PRIORITY == strict ]]; then
+            # If the channel priority is strict we should fail instead of silently
+            # changing how the solve is done.
+            echo "WARNING: May not be able to solve this environment with pinnings and strict channel priority"
+            # Keep going, because retry_on_known_errors now checks for pinning
+            # problems and will trigger a pip fallback if they continue.
+        fi
+
+        # Add the free channel, which might fix this...
+        conda config --set restore_free_channel true
+
+        # Try the dry run again, fail if pinnings are still ignored
+        echo "Re-running with free channel restored"
+
+        conda install --dry-run $CONDA_DEPENDENCIES 2>&1 | tee $_tmp_output_file
+
+        if [[ ! -z $(grep "conflicts with explicit specs" $_tmp_output_file) ]]; then
+            # No clue how to fix this, so just give up
+            echo "WARNING: conda is ignoring pinnings"
+            # Actually, just continue. retry_on_known_errors now checks for
+            # pinning problems and will trigger a pip fallback if they continue.
+        fi
+    fi
+
+    # Clean up
+    rm -f $_tmp_output_file
+fi
+
 # NUMPY
+
+# Older versions of numpy are only available on the "free" channel, which
+# has been removed as of conda 4.7 from the list of default channels.
+# This adds it back if needed.
+
+if [[ ! -z $NUMPY_VERSION ]]; then
+    # We only want to do a check for old versions of numpy, not for dev or stable
+    if [[ $NUMPY_VERSION =~ [0-9]+(\.[0-9]){1,2} ]]; then
+        old_numpy=$(python -c "from distutils.version import LooseVersion;\
+                    import os;\
+                    print(LooseVersion(os.environ['NUMPY_VERSION']) <\
+                          LooseVersion('1.11.0'))")
+        if [[ $old_numpy == True ]]; then
+            conda config --set restore_free_channel true
+        fi
+    fi
+fi
+
 # We use --no-pin to avoid installing other dependencies just yet.
 
 
@@ -524,9 +674,15 @@ if [[ $SETUP_CMD == *build_sphinx* ]] || [[ $SETUP_CMD == *build_docs* ]]; then
         retry_on_known_error $CONDA_INSTALL $package && mv /tmp/pin_file_copy $PIN_FILE || ( \
             $PIP_FALLBACK && (\
             echo "Installing $package with conda was unsuccessful, using pip instead."
-            PIP_PACKAGE_VERSION=$(awk '{print $2}' $PIN_FILE)
+            PIP_PACKAGE_VERSION=$(grep $package $PIN_FILE | awk '{print $2}')
+            # Debugging....
+            echo "WHAT IS GOING ON HERE (TAKE 2)"
+            conda info -a
+            conda config --show
+            conda list
+            cat $PIN_FILE
             if [[ $(echo $PIP_PACKAGE_VERSION | cut -c 1) =~ $is_number ]]; then
-                PIP_PACKAGE_VERSION='=='${PIP_${package}_VERSION}
+                PIP_PACKAGE_VERSION='=='${PIP_PACKAGE_VERSION}
             elif [[ $(echo $PIP_PACKAGE_VERSION | cut -c 1-2) =~ $is_eq_number ]]; then
                 PIP_PACKAGE_VERSION='='${PIP_PACKAGE_VERSION}
             fi
@@ -747,7 +903,8 @@ fi
 
 if [[ $DEBUG == True ]]; then
     # include debug information about the current conda install
-    conda install -n root _license
+    # There was once an install of a _license package here, which does not
+    # exist for python >=3.7
     conda info -a
 fi
 

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -390,7 +390,10 @@ if [[ ! -z $CONDA_DEPENDENCIES ]]; then
     #
     # Use tee to print output to console and to file to avoid travis timing out
     _tmp_output_file="tmp.txt"
+    # do not exit on failure of the dry run because pip fallback may succeed
+    set +e
     conda install --dry-run $CONDA_DEPENDENCIES > >(tee $_tmp_output_file) 2>&1
+    set -e
     # 'grep' returns non-zero exit status if no lines match.
     if [[ ! -z $(grep "conflicts with explicit specs" $_tmp_output_file) ]]; then
         echo "restoring free channel"
@@ -413,7 +416,10 @@ if [[ ! -z $CONDA_DEPENDENCIES ]]; then
         # Try the dry run again, fail if pinnings are still ignored
         echo "Re-running with free channel restored"
 
+        # do not exit on failure of the dry run because pip fallback may succeed
+        set +e
         conda install --dry-run $CONDA_DEPENDENCIES > >(tee $_tmp_output_file) 2>&1
+        set -e
         if [[ ! -z $(grep "conflicts with explicit specs" $_tmp_output_file) ]]; then
             # No clue how to fix this, so just give up
             echo "WARNING: conda is ignoring pinnings"

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -53,6 +53,7 @@ function retry_on_known_error() {
         # there is no output on travis for that long, the job is cancelled.
         set +e
         $@ > $_tmp_output_file 2>&1
+        cat $_tmp_output_file
         _exitval="$?"
         set -e
 

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -405,7 +405,7 @@ if [[ ! -z $CONDA_DEPENDENCIES ]]; then
 
         # ...but only if the free channel is not ruled out by strict
         # channel priority
-        if [[ ! -z $CONDA_CHANNEL_PRIORITY && $CONDA_CHANNEL_PRIORITY == strict ]]; then
+        if [[ $CONDA_CHANNEL_PRIORITY == strict ]]; then
             # If the channel priority is strict we should fail instead of silently
             # changing how the solve is done.
             echo "WARNING: May not be able to solve this environment with pinnings and strict channel priority"

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -52,10 +52,6 @@ function retry_on_known_error() {
         # the event a conda solve takes a really long time (>10 min). If
         # there is no output on travis for that long, the job is cancelled.
         set +e
-        if [[ $TRAVIS_OS_NAME == windows ]]; then
-            echo $PWD
-            echo "am i working" > >(tee junk) 2>&1
-        fi
         $@ > $_tmp_output_file 2>&1
         _exitval="$?"
         set -e

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -69,6 +69,15 @@ function retry_on_known_error() {
         # The hacky workaround is to identify overridden specs and add the
         # spec from the pin file back to the command line.
         if [[ -n $(grep "conflicts with explicit specs" $_tmp_output_file) ]]; then
+            # Roll back the command than generated the conflict message.
+            # To do this, we get the most recent environment revision number,
+            # then roll back to the one before that.
+            # To ensure we don't need to activate, direct output of conda to
+            # a file instead of piping
+            _revision_file="revisions.txt"
+            conda list --revision > _revision_file
+            _current_revision=$(cat _revision_file | grep \(rev | tail -1 | cut -d' ' -f5 | cut -d')' -f1)
+            conda install --revision=$(( $_current_revision - 1 ))
             _tmp_spec_conflicts=bad_spec.txt
             # Isolate the problematic specs
             grep "conflicts with explicit specs" $_tmp_output_file > $_tmp_spec_conflicts

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -52,6 +52,9 @@ function retry_on_known_error() {
         # the event a conda solve takes a really long time (>10 min). If
         # there is no output on travis for that long, the job is cancelled.
         set +e
+        if [[ $TRAVIS_OS_NAME == windows ]]; then
+            echo $PWD
+        fi
         $@ > >(tee $_tmp_output_file) 2>&1
         _exitval="$?"
         set -e

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -53,8 +53,10 @@ function retry_on_known_error() {
         # there is no output on travis for that long, the job is cancelled.
         set +e
         $@ > $_tmp_output_file 2>&1
-        cat $_tmp_output_file
         _exitval="$?"
+        # Keep the cat here...otherwise _exitval is always 0
+        # even if the conda install failed.
+        cat $_tmp_output_file
         set -e
 
         # The hack below is to work around a bug in conda 4.7 in which a spec

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -136,7 +136,7 @@ fi
 # We pin the version for conda as it's not the most stable package from
 # release to release. Add note here if version is pinned due to a bug upstream.
 if [[ -z $CONDA_VERSION ]]; then
-    CONDA_VERSION=4.5.12
+    CONDA_VERSION=4.7
 fi
 
 if [[ -z $PIN_FILE_CONDA ]]; then

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -54,8 +54,9 @@ function retry_on_known_error() {
         set +e
         if [[ $TRAVIS_OS_NAME == windows ]]; then
             echo $PWD
+            echo "am i working" > >(tee junk) 2>&1
         fi
-        $@ > >(tee $_tmp_output_file) 2>&1
+        $@ > $_tmp_output_file 2>&1
         _exitval="$?"
         set -e
 
@@ -395,6 +396,7 @@ if [[ ! -z $CONDA_DEPENDENCIES ]]; then
     _tmp_output_file="tmp.txt"
     # do not exit on failure of the dry run because pip fallback may succeed
     set +e
+
     conda install --dry-run $CONDA_DEPENDENCIES > >(tee $_tmp_output_file) 2>&1
     set -e
     # 'grep' returns non-zero exit status if no lines match.


### PR DESCRIPTION
We should consider using strict channel priority for all the builds because it can speed up installation considerably. For now I've just replace `true` with `strict`.

I am quite sure some of the appveyor builds are going to break because they use quite old python versions.