### PR TITLE
Adding test-cov as a valid coverage trigger

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ environment variables
   are installed:
 
     * ``--coverage``: the coverage, coveralls, and codecov packages are installed
-    * ``--cov``: the pytest-cov, coveralls, and codecov packages are installed
+    * ``-cov``: the pytest-cov, coveralls, and codecov packages are installed
     * ``--parallel`` or ``--numprocesses``: the pytest-xdist package is
       installed
     * ``--open-files``: the psutil package is installed

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -727,9 +727,8 @@ if [[ $SETUP_CMD == *coverage* ]]; then
     $PIP_INSTALL coveralls codecov
 fi
 
-if [[ $SETUP_CMD == *--cov* ]]; then
-    retry_on_known_error $CONDA_INSTALL pytest-cov
-    $PIP_INSTALL coveralls codecov
+if [[ $SETUP_CMD == *-cov* ]]; then
+    $PIP_INSTALL coveralls codecov pytest-cov
 fi
 
 


### PR DESCRIPTION
Covering case when coverage testing triggered with e.g.  command, in e.g. gammapy