### PR TITLE
pip install astropy-dev build dependencies

### DIFF
--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -811,9 +811,8 @@ fi
 # sure that Numpy doesn't get upgraded.
 
 if [[ $ASTROPY_VERSION == dev* ]]; then
-    retry_on_known_error $CONDA_INSTALL Cython jinja2
-
-    $PIP_INSTALL git+https://github.com/astropy/astropy.git#egg=astropy pytest-astropy --upgrade --no-deps
+    $PIP_INSTALL Cython jinja2 pytest-astropy
+    $PIP_INSTALL git+https://github.com/astropy/astropy.git#egg=astropy --upgrade --no-deps
 fi
 
 if [[ $ASTROPY_VERSION == pre* ]]; then

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -811,9 +811,9 @@ fi
 # sure that Numpy doesn't get upgraded.
 
 if [[ $ASTROPY_VERSION == dev* ]]; then
-    retry_on_known_error $CONDA_INSTALL Cython jinja2 pytest-astropy
+    retry_on_known_error $CONDA_INSTALL Cython jinja2
 
-    $PIP_INSTALL git+https://github.com/astropy/astropy.git#egg=astropy --upgrade --no-deps
+    $PIP_INSTALL git+https://github.com/astropy/astropy.git#egg=astropy pytest-astropy --upgrade --no-deps
 fi
 
 if [[ $ASTROPY_VERSION == pre* ]]; then


### PR DESCRIPTION
This should fix the latest failures on photutils CI (e.g. when we have a new pytest-astropy release, but it doesn't yet propagated through conda)