### PR TITLE
Added script that can be used for tox builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ env:
         - SETUP_CMD='test'
         - TEST_CMD='py.test test_env.py'
         - PYTHON_VERSION=3.6
+        - SETUP_CONDA=true
 
     matrix:
         - SETUP_CMD='egg_info' TEST_CMD='python --version'
@@ -254,6 +255,11 @@ matrix:
           env: SETUP_CMD='test' CONDA_ENVIRONMENT='conda_environment.yml' CONDA_DEPENDENCIES="scipy"
                TEST_CMD="python -c $'import matplotlib\nimport scipy'"
 
+        - os: linux
+          python: 3.7
+          language: python
+          env: SETUP_CONDA=false TOXENV="test" TEST_CMD="source ci-helpers/tox/run_tox.sh && test -f tox_worked.log"
+
     allow_failures:
         # JOB .34
         - os: linux
@@ -266,9 +272,10 @@ before_install:
       else
         ln -s . ci-helpers;
       fi
-    - source ci-helpers/travis/setup_conda.sh
+    - if [[ $SETUP_CONDA == true ]]; then source ci-helpers/travis/setup_conda.sh; fi
 
 script:
+   - python --version
    - eval $TEST_CMD
 
 after_success:

--- a/README.md
+++ b/README.md
@@ -280,6 +280,29 @@ environment variables:
 * ``RETRY_DELAY``: a positive integer specifying the number of seconds to wait
   before retrying. If not set, this will default to ``$RETRY_DELAY=2``.
 
+### Tox
+
+For CI builds using tox, we also provide a script that installs and runs tox, assuming that the following environment
+variables are defined:
+
+* ``TOXENV``: the name of the tox environment to run
+* ``TOXARGS``: the arguments to pass to tox
+* ``TOXPOSARGS``: the positional arguments to pass after the ``--`` separator
+
+The resulting tox command looks like::
+
+    tox -e $TOXENV $TOXPOSARGS -- $TOXPOSARGS
+
+This script may also apply patches, for example to prevent a too recent version
+of pytest from being installed if this breaks many packages, or excluding a
+broken version of another package. This is done by running a proxy PyPI server
+which excludes the problematic package versions. In general however, the goal
+will be to not have any patches most of the time and to only use this in extreme
+circumstances.
+
+Note that this script will not set up conda and will by default just use the
+active Python interpreter. Aside from the three environment variables mentioned
+in this section, no other environment variables are taken into account.
 
 ### Utils
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,9 @@
+[tox]
+envlist = test
+
+[testenv]
+skip_install = true
+whitelist_externals =
+    touch
+commands =
+    touch tox_worked.log

--- a/tox/run_tox.sh
+++ b/tox/run_tox.sh
@@ -1,0 +1,53 @@
+#!/bin/bash -xe
+
+# This script installs and runs tox, assuming that the following environment
+# variables are defined:
+#
+# * TOXENV: the name of the tox environment to run
+# * TOXARGS: the arguments to pass to tox
+# * TOXPOSARGS: the positional arguments to pass after the -- separator
+#
+# The resulting tox command looks like:
+#
+#     tox -e $TOXENV $TOXPOSARGS -- $TOXPOSARGS
+#
+# This script may also apply patches, for example to prevent a too recent
+# version of pytest from being installed, or excluding a broken version of
+# another package. This is done by running a proxy PyPI server which
+# excludes the problematic package versions.
+
+echo '########################################################################'
+echo ''
+echo 'ci-helpers run_tox.sh script'
+echo ''
+echo 'TOXENV='$TOXENV
+echo 'TOXARGS='$TOXARGS
+echo 'TOXPOSARGS='$TOXPOSARGS
+echo ''
+echo 'No global patches being applied'
+echo ''
+echo 'Installing tox:'
+echo ''
+
+# Start off by installing tox
+pip install tox
+
+# If PyPI patches are needed, uncommend the following line
+# pip install tox-pypi-filter
+
+echo ''
+echo 'Listing Python packages:'
+echo ''
+
+# List the current installed packages
+pip freeze
+
+echo ''
+echo 'Running tox:'
+echo ''
+
+# Run tox. If PyPI patches are needed, add a --pypi-filter=...
+# option to the command, e.g. --pypi-filter='pytest<5'
+tox -e $TOXENV $TOXARGS -- $TOXPOSARGS
+echo ''
+echo '########################################################################'


### PR DESCRIPTION
This script installs and run tox, and optionally applies global patches if needed. The idea is to keep this super minimal even in the case where patches need to be applied.

I tried a slightly different approach of leaving it to the caller to actually run the tox command, and using the script to just modify the environment variables, but this didn't work because of issues with quotes in bash, which would require the final tox command to be convoluted.

For now, this script does not do any patching.

I've temporarily disabled all other Travis builds to make sure the one I added works, in case iteration is needed, without wasting CI time.