### PR TITLE
Update the version numbers

### DIFF
--- a/test_env.py
+++ b/test_env.py
@@ -33,10 +33,10 @@ if 'TRAVIS_REPO_SLUG' in os.environ:
 
 
 if not LooseVersion(sys.version) < '3.5':
-    LATEST_ASTROPY_STABLE = '3.2.3'
+    LATEST_ASTROPY_STABLE = '4.0'
     # This is not for windows but appveyor only
     LATEST_ASTROPY_STABLE_WIN = '3.2.2'
-    LATEST_NUMPY_STABLE = '1.17'
+    LATEST_NUMPY_STABLE = '1.18'
 else:
     LATEST_ASTROPY_STABLE = '2.0.16'
     # This is not for windows but appveyor only
@@ -47,7 +47,7 @@ LATEST_ASTROPY_LTS = '2.0.16'
 # This is not for windows but appveyor only
 LATEST_ASTROPY_LTS_WIN = '2.0.15'
 LATEST_NUMPY_STABLE_WIN = '1.16'
-LATEST_SUNPY_STABLE = '1.0.3'
+LATEST_SUNPY_STABLE = '1.0.6'
 
 if os.environ.get('PIP_DEPENDENCIES', None) is not None:
     PIP_DEPENDENCIES = os.environ['PIP_DEPENDENCIES'].split(' ')

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -153,15 +153,15 @@ fi
 # We will use the 2.0.x releases as "stable" for Python 2.7 and 3.4
 if [[ $(python -c "from distutils.version import LooseVersion; import os;\
         print(LooseVersion(os.environ['PYTHON_VERSION']) < '3.5')") == False ]]; then
-    export LATEST_ASTROPY_STABLE=3.2.3
-    export LATEST_NUMPY_STABLE=1.17
+    export LATEST_ASTROPY_STABLE=4.0
+    export LATEST_NUMPY_STABLE=1.18
 else
     export LATEST_ASTROPY_STABLE=2.0.16
     export NO_PYTEST_ASTROPY=True
     export LATEST_NUMPY_STABLE=1.16
 fi
 export ASTROPY_LTS_VERSION=2.0.16
-export LATEST_SUNPY_STABLE=1.0.3
+export LATEST_SUNPY_STABLE=1.0.6
 
 
 is_number='[0-9]'


### PR DESCRIPTION
Neither astropy nor numpy made it to conda defaults yet, but if these are picked up for pip install without issue, I'll go ahead and merge 

(haven't yet updated the LTS version numbers)