### PR TITLE
Limit coverage version number

### DIFF
--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -882,7 +882,8 @@ fi
 
 if [[ $SETUP_CMD == *coverage* ]]; then
     # We install requests with conda since it's required by coveralls.
-    retry_on_known_error $CONDA_INSTALL coverage requests
+    # Limit the version number as the astropy testrunner is not compatible with v5
+    retry_on_known_error $CONDA_INSTALL 'coverage<5' requests
     $PIP_INSTALL coveralls codecov
 fi
 


### PR DESCRIPTION
To close https://github.com/astropy/astropy/issues/9792 and fix the coverage related CI failure in packages using the astropy test runner. 

As it's mentioned in the PR we're not planning to patch over the test runner, given it's being factored out in the next release. If this version limit starts to become burdensome, it can be patched over with an env variable, but I would rather keep it simple for now.