### PR TITLE
Limiting pytest to be <5.4 temporarily

### DIFF
--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -263,6 +263,12 @@ fi
 
 # CORE DEPENDENCIES
 
+# Temporary version limitation, remove once
+# https://github.com/astropy/pytest-doctestplus/issues/94 is fixed and released
+if [[ -z $PYTEST_VERSION ]]; then
+    PYTEST_VERSION="<5.4"
+fi
+
 if [[ ! -z $PYTEST_VERSION ]]; then
     echo "pytest ${PYTEST_VERSION}.*" >> $PIN_FILE
 fi


### PR DESCRIPTION
New pytest 5.4 is causing troubles, limiting the version temporarily until a new doctestplus release is done.