### PR TITLE
Pin pytest to <5.4 in tox script

### DIFF
--- a/tox/run_tox.sh
+++ b/tox/run_tox.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -xe
+#!/bin/bash
 
 # This script installs and runs tox, assuming that the following environment
 # variables are defined:
@@ -16,6 +16,8 @@
 # another package. This is done by running a proxy PyPI server which
 # excludes the problematic package versions.
 
+set -xe
+
 echo '########################################################################'
 echo ''
 echo 'ci-helpers run_tox.sh script'
@@ -24,7 +26,8 @@ echo 'TOXENV='$TOXENV
 echo 'TOXARGS='$TOXARGS
 echo 'TOXPOSARGS='$TOXPOSARGS
 echo ''
-echo 'No global patches being applied'
+# echo 'No global patches being applied'
+echo 'Patching pytest to <5.4'
 echo ''
 echo 'Installing tox:'
 echo ''

--- a/tox/run_tox.sh
+++ b/tox/run_tox.sh
@@ -16,7 +16,7 @@
 # another package. This is done by running a proxy PyPI server which
 # excludes the problematic package versions.
 
-set -xe
+set -e
 
 echo '########################################################################'
 echo ''
@@ -51,6 +51,6 @@ echo ''
 
 # Run tox. If PyPI patches are needed, add a --pypi-filter=...
 # option to the command, e.g. --pypi-filter='pytest<5'
-tox -e $TOXENV $TOXARGS --pypi-filter="pytest<5.4" -- $TOXPOSARGS
+tox -e $TOXENV $TOXARGS --pypi-filter='pytest<5.4' -- $TOXPOSARGS
 echo ''
 echo '########################################################################'

--- a/tox/run_tox.sh
+++ b/tox/run_tox.sh
@@ -26,8 +26,13 @@ echo 'TOXENV='$TOXENV
 echo 'TOXARGS='$TOXARGS
 echo 'TOXPOSARGS='$TOXPOSARGS
 echo ''
+
+# Temporary version limitation, remove here and below once
+# https://github.com/astropy/pytest-doctestplus/issues/94 is fixed and released
+
 # echo 'No global patches being applied'
 echo 'Patching pytest to <5.4'
+
 echo ''
 echo 'Installing tox:'
 echo ''

--- a/tox/run_tox.sh
+++ b/tox/run_tox.sh
@@ -33,7 +33,7 @@ echo ''
 pip install tox
 
 # If PyPI patches are needed, uncommend the following line
-# pip install tox-pypi-filter
+pip install tox-pypi-filter
 
 echo ''
 echo 'Listing Python packages:'
@@ -48,6 +48,6 @@ echo ''
 
 # Run tox. If PyPI patches are needed, add a --pypi-filter=...
 # option to the command, e.g. --pypi-filter='pytest<5'
-tox -e $TOXENV $TOXARGS -- $TOXPOSARGS
+tox -e $TOXENV $TOXARGS --pypi-filter='pytest<5.4' -- $TOXPOSARGS
 echo ''
 echo '########################################################################'

--- a/tox/run_tox.sh
+++ b/tox/run_tox.sh
@@ -51,6 +51,6 @@ echo ''
 
 # Run tox. If PyPI patches are needed, add a --pypi-filter=...
 # option to the command, e.g. --pypi-filter='pytest<5'
-tox -e $TOXENV $TOXARGS --pypi-filter='pytest<5.4' -- $TOXPOSARGS
+tox -e $TOXENV $TOXARGS --pypi-filter="pytest<5.4" -- $TOXPOSARGS
 echo ''
 echo '########################################################################'


### PR DESCRIPTION
This pins pytest to <5.4 in the tox script. Currently testing this in https://github.com/astropy/astropy/pull/10045