### PR TITLE
Pin pytest-doctestplus

### DIFF
--- a/pip_pinnings.txt
+++ b/pip_pinnings.txt
@@ -1,1 +1,2 @@
 pytest<5.4
+pytest-doctestplus<0.6


### PR DESCRIPTION
To get rid of CI failures for astropy 4.1 feature freeze.