### PR TITLE
TST: Update LTS job on Appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,7 +25,7 @@ environment:
 
       - PYTHON_VERSION: "3.6"
         NUMPY_VERSION: "1.16"
-        PYTEST_VERSION: "=3.6.4"
+        PYTEST_VERSION: "=4.6.9"
         ASTROPY_VERSION: "lts"
 
       - PYTHON_VERSION: "3.7"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,7 +25,7 @@ environment:
 
       - PYTHON_VERSION: "3.6"
         NUMPY_VERSION: "1.16"
-        PYTEST_VERSION: "=4.6.9"
+        PYTEST_VERSION: "=4.6"
         ASTROPY_VERSION: "lts"
 
       - PYTHON_VERSION: "3.7"


### PR DESCRIPTION
pytest-openfiles that LTS pulls need pytest>=4.6 now.