### PR TITLE
Install pyerfa for astropy dev

### DIFF
--- a/appveyor/install-miniconda.ps1
+++ b/appveyor/install-miniconda.ps1
@@ -445,9 +445,11 @@ if ($env:NUMPY_VERSION -match "dev") {
    checkLastExitCode
 }
 
+# TODO: Use conda to install pyerfa when it is available.
 # Check whether the developer version of Astropy is required and if yes install
 # it. We need to include --no-deps to make sure that Numpy doesn't get upgraded.
 if ($env:ASTROPY_VERSION -match "dev") {
+   Invoke-Expression "${env:CMD_IN_ENV} pip install pyerfa --upgrade --no-deps"
    Invoke-Expression "${env:CMD_IN_ENV} pip install git+https://github.com/astropy/astropy.git#egg=astropy --upgrade --no-deps"
    checkLastExitCode
 }

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -830,7 +830,7 @@ fi
 # sure that Numpy doesn't get upgraded.
 
 if [[ $ASTROPY_VERSION == dev* ]]; then
-    $PIP_INSTALL Cython jinja2 pytest-astropy
+    $PIP_INSTALL Cython jinja2 pytest-astropy pyerfa
     $PIP_INSTALL git+https://github.com/astropy/astropy.git#egg=astropy --upgrade --no-deps
 fi
 


### PR DESCRIPTION
To get around CI downstream failing because there is no pyerfa for astropy dev. Also see astropy/astropy#10329