### PR TITLE
Fix mamba installation to work when installing dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,8 @@ environment variables
 * ``MAMBA``: if set to ``True``, conda packages
   will be installed with `mamba <https://github.com/mamba-org/mamba>`_, which is
   both faster than conda and gives more readable errors in cases where there are
-  conflicts.
+  conflicts. Note that if using ``CONDA_ENVIRONMENT`` you must include ``mamba``
+  as a dependency in addition to setting this to ``True``.
 
 * ``NUMPY_VERSION``: if set to ``dev`` or ``development``, the latest
   developer version of Numpy is installed along with Cython. If set to a

--- a/README.md
+++ b/README.md
@@ -76,8 +76,7 @@ environment variables
 * ``MAMBA``: if set to ``True``, conda packages
   will be installed with `mamba <https://github.com/mamba-org/mamba>`_, which is
   both faster than conda and gives more readable errors in cases where there are
-  conflicts. Note that if using ``CONDA_ENVIRONMENT`` you must include ``mamba``
-  as a dependency in addition to setting this to ``True``.
+  conflicts.
 
 * ``NUMPY_VERSION``: if set to ``dev`` or ``development``, the latest
   developer version of Numpy is installed along with Cython. If set to a

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -265,10 +265,10 @@ fi
 
 # install mamba and use it from now on
 if [[ $MAMBA == True ]]; then
-    CONDA_INSTALL_COMMAND='mamba install';
+    CONDA_INSTALL_COMMAND='mamba install'
     conda install -c conda-forge mamba
 else
-    CONDA_INSTALL_COMMAND='conda install';
+    CONDA_INSTALL_COMMAND='conda install'
 fi
 
 # CORE DEPENDENCIES

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -169,10 +169,13 @@ is_eq_number='=[0-9]'
 is_eq_float="=[0-9]+\.[0-9]+"
 
 if [[ $MAMBA == True ]]; then
-    conda install -c conda-forge mamba;
     CONDA_INSTALL_COMMAND='mamba install';
+    # mamba is not automatically linked like 'conda' so we need to install it
+    # in all new environments
+    MAMBA_DEPS='mamba';
 else
     CONDA_INSTALL_COMMAND='conda install';
+    MAMBA_DEPS='';
 fi
 
 if [[ -z $PIP_FALLBACK ]]; then
@@ -197,7 +200,7 @@ fi
 # release to release. Add note here if version is pinned due to a bug upstream.
 if [[ -z $CONDA_VERSION ]]; then
     if [[ $MAMBA == True ]]; then
-        CONDA_VERSION=4.8.4
+        CONDA_VERSION=">=4.8"
     else
         CONDA_VERSION=4.7.11
     fi
@@ -209,7 +212,7 @@ fi
 
 echo "conda ${CONDA_VERSION}" > $PIN_FILE_CONDA
 
-retry_on_known_error conda install $QUIET conda
+retry_on_known_error conda install $QUIET conda $MAMBA_DEPS
 
 if [[ -z $CONDA_CHANNEL_PRIORITY ]]; then
     CONDA_CHANNEL_PRIORITY=disabled
@@ -248,7 +251,7 @@ fi
 
 # CONDA
 if [[ -z $CONDA_ENVIRONMENT ]]; then
-    retry_on_known_error conda create $QUIET -n test $PYTHON_OPTION
+    retry_on_known_error conda create $QUIET -n test $PYTHON_OPTION $MAMBA_DEPS
 else
     retry_on_known_error conda env create $QUIET -n test -f $CONDA_ENVIRONMENT
 fi

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -240,7 +240,7 @@ fi
 
 # CONDA
 if [[ -z $CONDA_ENVIRONMENT ]]; then
-    retry_on_known_error $CONDA_INSTALL_COMMAND create $QUIET -n test $PYTHON_OPTION
+    retry_on_known_error conda create $QUIET -n test $PYTHON_OPTION
 else
     retry_on_known_error conda env create $QUIET -n test -f $CONDA_ENVIRONMENT
 fi

--- a/travis/setup_dependencies_common.sh
+++ b/travis/setup_dependencies_common.sh
@@ -168,16 +168,6 @@ is_number='[0-9]'
 is_eq_number='=[0-9]'
 is_eq_float="=[0-9]+\.[0-9]+"
 
-if [[ $MAMBA == True ]]; then
-    CONDA_INSTALL_COMMAND='mamba install';
-    # mamba is not automatically linked like 'conda' so we need to install it
-    # in all new environments
-    MAMBA_DEPS='mamba';
-else
-    CONDA_INSTALL_COMMAND='conda install';
-    MAMBA_DEPS='';
-fi
-
 if [[ -z $PIP_FALLBACK ]]; then
     PIP_FALLBACK=true
 fi
@@ -212,7 +202,7 @@ fi
 
 echo "conda ${CONDA_VERSION}" > $PIN_FILE_CONDA
 
-retry_on_known_error conda install $QUIET conda $MAMBA_DEPS
+retry_on_known_error conda install $QUIET conda
 
 if [[ -z $CONDA_CHANNEL_PRIORITY ]]; then
     CONDA_CHANNEL_PRIORITY=disabled
@@ -248,10 +238,9 @@ if [[ $PYTHON_VERSION == 3.4* ]]; then
     conda config --set restore_free_channel true
 fi
 
-
 # CONDA
 if [[ -z $CONDA_ENVIRONMENT ]]; then
-    retry_on_known_error conda create $QUIET -n test $PYTHON_OPTION $MAMBA_DEPS
+    retry_on_known_error $CONDA_INSTALL_COMMAND create $QUIET -n test $PYTHON_OPTION
 else
     retry_on_known_error conda env create $QUIET -n test -f $CONDA_ENVIRONMENT
 fi
@@ -272,6 +261,14 @@ fi
 # EGG_INFO
 if [[ $SETUP_CMD == egg_info ]]; then
     return  # no more dependencies needed
+fi
+
+# install mamba and use it from now on
+if [[ $MAMBA == True ]]; then
+    CONDA_INSTALL_COMMAND='mamba install';
+    conda install -c conda-forge mamba
+else
+    CONDA_INSTALL_COMMAND='conda install';
 fi
 
 # CORE DEPENDENCIES


### PR DESCRIPTION
Close #460 

Mamba is not treated like the `conda` binary where it is copied to all sub-environments. This meant that once we activated our new `test` environment the `mamba` command was no longer available. We have to make sure `mamba` is installed as a dependency in this new environment if we want to use it.

CC @astrofrog who originally wrote #457 