### PR TITLE
Add script to set up Python without conda

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ env:
         - SETUP_CMD='test'
         - TEST_CMD='py.test test_env.py'
         - PYTHON_VERSION=3.6
-        - SETUP_CONDA=true
+        - SETUP_MODE=conda
 
     jobs:
         - SETUP_CMD='egg_info' TEST_CMD='python --version'
@@ -265,6 +265,16 @@ jobs:
           env: SETUP_CMD='test' NUMPY_VERSION=stable ASTROPY_VERSION=lts
                CONDA_DEPENDENCIES='scipy' MAMBA=True
 
+        # JOB .34
+        # -> Installation on MacOS X without conda
+        - os: osx
+          env: SETUP_MODE='native' PYTHON_VERSION=3.7
+
+        # JOB .35
+        # -> Installation on Windows without conda
+        - os: windows
+          env: SETUP_MODE='native' PYTHON_VERSION=3.7
+
     allow_failures:
         # JOB .34
         - os: linux
@@ -277,7 +287,11 @@ before_install:
       else
         ln -s . ci-helpers;
       fi
-    - if [[ $SETUP_CONDA == true ]]; then source ci-helpers/travis/setup_conda.sh; fi
+    - if [[ $SETUP_MODE == conda ]]; then source ci-helpers/travis/setup_conda.sh; fi
+    - if [[ $SETUP_MODE == native ]]; then
+        source ci-helpers/travis/setup_python.sh;
+        python -m pip install pytest;
+      fi
 
 script:
    - python --version

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ How to use
 
 ### Travis (with conda)
 
+*Note that you can also set up Python without conda using ci-helpers - see [here](#setting-up-python-without-conda-on-travis) for more details*
+
 Include the following lines at the start of the ``install`` section in
 ``.travis.yml``:
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ For the usage of the deprecated scripts see [Appveyor scripts README](https://gi
 How to use
 ----------
 
-### Travis
+### Travis (with conda)
 
 Include the following lines at the start of the ``install`` section in
 ``.travis.yml``:
@@ -220,6 +220,29 @@ Python and Numpy versions stay fixed to those requested, e.g.
 - $CONDA_INSTALL another_package
 ```
 
+### Setting up Python without conda on Travis
+
+We also provide a script to set up Python on MacOS X and Windows without making
+use of conda. To use this include the following lines at the start of the
+``install`` section in ``.travis.yml``:
+
+```yaml
+install:
+    - git clone --depth 1 git://github.com/astropy/ci-helpers.git
+    - source ci-helpers/travis/setup_python.sh
+```
+
+You will need to set the ``PYTHON_VERSION`` environment variable to the
+major.minor version of Python that you want to have installed (e.g. 3.8)
+
+The script does nothing on Linux, so it is safe to call as above without special
+casing the operating system. On Linux, you should instead use ``language:
+python`` provide the Python version with ``python: ...``.
+
+The script also sets up a virtual environment using
+[venv](https://docs.python.org/3/library/venv.html) and upgrades pip to the
+latest version, but does not install any other packages. This is deliberate as we want to keep this script as minimal as possible.
+
 ### pip pinnings
 
 We also provide a file called
@@ -251,6 +274,7 @@ The scripts include:
   this directly rather than the OS specific ones below
 * ``travis/setup_conda_linux.sh`` - set up conda on Linux
 * ``travis/setup_conda_osx.sh`` - set up conda on MacOS X
+* ``travis/setup_python.sh`` - set up Python on MacOS X and Windows without conda
 
 This repository can be cloned directly from the ``.travis.yml``
 file when about to run tests and does not need to be included

--- a/test_env.py
+++ b/test_env.py
@@ -76,7 +76,7 @@ def test_python_version():
 
 
 def test_exported_variables():
-    if 'TRAVIS' in os.environ:
+    if 'TRAVIS' in os.environ and os.environ.get('SETUP_MODE', '') == 'conda':
         assert os.environ.get('ASTROPY_LTS_VERSION', '') == LATEST_ASTROPY_LTS
         assert os.environ.get('LATEST_NUMPY_STABLE', '') == LATEST_NUMPY_STABLE
         assert os.environ.get('LATEST_SUNPY_STABLE', '') == LATEST_SUNPY_STABLE
@@ -262,9 +262,11 @@ def test_regression_mkl():
 
 def test_conda_channel_priority():
 
-    channel_priority = os.environ.get('CONDA_CHANNEL_PRIORITY', 'disabled')
+    if os.environ.get('SETUP_MODE', '') == 'conda':
 
-    with open(os.path.expanduser('~/.condarc'), 'r') as f:
-        content = f.read()
+        channel_priority = os.environ.get('CONDA_CHANNEL_PRIORITY', 'disabled')
 
-    assert 'channel_priority: {0}'.format(channel_priority.lower()) in content
+        with open(os.path.expanduser('~/.condarc'), 'r') as f:
+            content = f.read()
+
+        assert 'channel_priority: {0}'.format(channel_priority.lower()) in content

--- a/travis/setup_python.sh
+++ b/travis/setup_python.sh
@@ -5,7 +5,7 @@
 echo "==================== Starting executing ci-helpers scripts ====================="
 
 if [[ -z $PYTHON_VERSION ]]; then
-    echo "$PYTHON_VERSION needs to be set";
+    echo "PYTHON_VERSION needs to be set";
     exit 1;
 fi
 
@@ -31,6 +31,7 @@ if [[ $TRAVIS_OS_NAME == osx ]]; then
 
     wget https://www.python.org/ftp/python/$FULL_PYTHON_VERSION/python-$FULL_PYTHON_VERSION-macosx10.9.pkg
     sudo installer -pkg python-$FULL_PYTHON_VERSION-macosx10.9.pkg -target /
+    /Applications/Python\ $PYTHON_VERSION/Install\ Certificates.command
     python$PYTHON_VERSION -m venv ~/python;
     source ~/python/bin/activate;
     python -m pip install --upgrade pip;

--- a/travis/setup_python.sh
+++ b/travis/setup_python.sh
@@ -10,8 +10,9 @@ if [[ -z $PYTHON_VERSION ]]; then
 fi
 
 if [[ $TRAVIS_OS_NAME == windows ]]; then
+    CONDENSED_PYTHON_VERSION="${PYTHON_VERSION//.}"
     choco install --no-progress python --version $PYTHON_VERSION;
-    export PATH="/c/Python37:/c/Python37/Scripts:$PATH"
+    export PATH="/c/Python$CONDENSED_PYTHON_VERSION:/c/Python$CONDENSED_PYTHON_VERSION/Scripts:$PATH"
     python3 -m venv ~/python;
     source ~/python/bin/activate;
     python -m pip install --upgrade pip;

--- a/travis/setup_python.sh
+++ b/travis/setup_python.sh
@@ -1,0 +1,42 @@
+#!/bin/bash -ex
+
+# Script to set up Python using native platform tools rather than conda
+
+echo "==================== Starting executing ci-helpers scripts ====================="
+
+if [[ -z $PYTHON_VERSION ]]; then
+    echo "$PYTHON_VERSION needs to be set";
+    exit 1;
+fi
+
+if [[ $TRAVIS_OS_NAME == windows ]]; then
+    choco install --no-progress python --version $PYTHON_VERSION;
+    export PATH="/c/Python37:/c/Python37/Scripts:$PATH"
+    python3 -m venv ~/python;
+    source ~/python/bin/activate;
+    python -m pip install --upgrade pip;
+fi
+
+if [[ $TRAVIS_OS_NAME == osx ]]; then
+
+    if [[ $PYTHON_VERSION == 3.6 ]]; then
+        FULL_PYTHON_VERSION=3.6.9;
+    elif [[ $PYTHON_VERSION == 3.7 ]]; then
+        FULL_PYTHON_VERSION=3.7.9;
+    elif [[ $PYTHON_VERSION == 3.8 ]]; then
+        FULL_PYTHON_VERSION=3.8.6;
+    elif [[ $PYTHON_VERSION == 3.9 ]]; then
+        FULL_PYTHON_VERSION=3.9.0;
+    fi
+
+    wget https://www.python.org/ftp/python/$FULL_PYTHON_VERSION/python-$FULL_PYTHON_VERSION-macosx10.9.pkg
+    sudo installer -pkg python-$FULL_PYTHON_VERSION-macosx10.9.pkg -target /
+    python$PYTHON_VERSION -m venv ~/python;
+    source ~/python/bin/activate;
+    python -m pip install --upgrade pip;
+fi
+
+echo "Checking default python version:"
+echo `python --version`
+
+echo "================= Returning executing local .travis.yml script ================="


### PR DESCRIPTION
Since the core package now uses choco to install Python on Windows and we might want to also avoid conda on MacOS X, I thought it would be handy to make a script that does all the set-up so we can use it across the organization as needed (the CI for the pytest plugins is having the same issues on Windows).

I am testing this out in https://github.com/astropy/astropy/pull/10871

### Why not use Homebrew on Mac?

It is quite slow and seems to download half the internet in some form of dependency hell.

### Why not use pyenv on Mac?

It downloads and builds Python from source so is very slow.

### Why use venv?

This is the easiest way to make sure we don't run into permissions issues and also makes available a ``python`` alias.

### Do we have to hard-code the bugfix mapping for MacOS X?

I could probably write a small script to try and do this automatically, but didn't want to spend too much time if we don't care.