### PR TITLE
Install latest bugfix for Windows and fix venv creation and activation

### DIFF
--- a/travis/setup_python.sh
+++ b/travis/setup_python.sh
@@ -9,26 +9,26 @@ if [[ -z $PYTHON_VERSION ]]; then
     exit 1;
 fi
 
+if [[ $PYTHON_VERSION == 3.6 ]]; then
+    FULL_PYTHON_VERSION=3.6.8;
+elif [[ $PYTHON_VERSION == 3.7 ]]; then
+    FULL_PYTHON_VERSION=3.7.9;
+elif [[ $PYTHON_VERSION == 3.8 ]]; then
+    FULL_PYTHON_VERSION=3.8.6;
+elif [[ $PYTHON_VERSION == 3.9 ]]; then
+    FULL_PYTHON_VERSION=3.9.0;
+fi
+
 if [[ $TRAVIS_OS_NAME == windows ]]; then
     CONDENSED_PYTHON_VERSION="${PYTHON_VERSION//.}"
-    choco install --no-progress python --version $PYTHON_VERSION;
+    choco install --no-progress python --version $FULL_PYTHON_VERSION;
     export PATH="/c/Python$CONDENSED_PYTHON_VERSION:/c/Python$CONDENSED_PYTHON_VERSION/Scripts:$PATH"
-    python3 -m venv ~/python;
-    source ~/python/bin/activate;
+    python -m venv ~/python;
+    source ~/python/Scripts/activate;
     python -m pip install --upgrade pip;
 fi
 
 if [[ $TRAVIS_OS_NAME == osx ]]; then
-
-    if [[ $PYTHON_VERSION == 3.6 ]]; then
-        FULL_PYTHON_VERSION=3.6.9;
-    elif [[ $PYTHON_VERSION == 3.7 ]]; then
-        FULL_PYTHON_VERSION=3.7.9;
-    elif [[ $PYTHON_VERSION == 3.8 ]]; then
-        FULL_PYTHON_VERSION=3.8.6;
-    elif [[ $PYTHON_VERSION == 3.9 ]]; then
-        FULL_PYTHON_VERSION=3.9.0;
-    fi
 
     wget https://www.python.org/ftp/python/$FULL_PYTHON_VERSION/python-$FULL_PYTHON_VERSION-macosx10.9.pkg
     sudo installer -pkg python-$FULL_PYTHON_VERSION-macosx10.9.pkg -target /


### PR DESCRIPTION
Follow-up of #462 - choco was installing the 3.x.0 versions instead of the latest bugfix and the venv creation and activation was broken.