### PR TITLE
Add support for other linux architectures on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,10 @@ env:
 
 jobs:
     include:
+        # ppc64le job
+        - arch: ppc64le
+          os: linux
+
         # pytest dev version
         - os: linux
           env: PYTHON_VERSION=3.8 PYTEST_VERSION=dev

--- a/travis/setup_conda_linux.sh
+++ b/travis/setup_conda_linux.sh
@@ -6,7 +6,12 @@
 if [[ -z "${MINICONDA_VERSION}" ]]; then
     MINICONDA_VERSION=4.7.10
 fi
-wget https://repo.continuum.io/miniconda/Miniconda3-${MINICONDA_VERSION}-Linux-x86_64.sh -O miniconda.sh --progress=dot:mega
+if [[ "${TRAVIS_CPU_ARCH}" == "amd64" ]]; then
+    MINICONDA_ARCH="x86_64"
+else
+    MINICONDA_ARCH="${TRAVIS_CPU_ARCH}"
+fi
+wget https://repo.continuum.io/miniconda/Miniconda3-${MINICONDA_VERSION}-Linux-${MINICONDA_ARCH}.sh -O miniconda.sh --progress=dot:mega
 # Create .conda directory before install to workaround conda bug
 # See https://github.com/ContinuumIO/anaconda-issues/issues/11148
 mkdir $HOME/.conda


### PR DESCRIPTION
Similar to #434, but for ppc64le which is distributed along side the x86_64 install scripts by anaconda.